### PR TITLE
TE-313 Adding throws Exception for generated unit tests

### DIFF
--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
@@ -53,6 +53,7 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 			}
 			// Create test method
 			members += test.toMethod('execute', typeRef(Void.TYPE)) [
+				exceptions += typeRef(Exception)
 				annotations += annotationRef('org.junit.Test') // make sure that junit is in the classpath of the workspace containing the dsl
 				body = '''«test.generateMethodBody»'''
 			]


### PR DESCRIPTION
Adding throws Exception to method signature of generated test methods.
This allows the fixture developers to throw exceptions in their code. SO they don't have to devlop an exception handling that causes the test to fail.