### PR TITLE
TE-372 minor fixes

### DIFF
--- a/aml/org.testeditor.aml.model/src/org/testeditor/aml/ModelUtil.xtend
+++ b/aml/org.testeditor.aml.model/src/org/testeditor/aml/ModelUtil.xtend
@@ -14,6 +14,7 @@ package org.testeditor.aml
 
 import java.util.HashSet
 import java.util.Set
+import org.eclipse.xtext.common.types.JvmType
 
 class ModelUtil {
 
@@ -85,6 +86,13 @@ class ModelUtil {
 		return template.contents.filter(TemplateVariable).filter [
 			!name.nullOrEmpty && name != TEMPLATE_VARIABLE_ELEMENT
 		].toSet
+	}
+
+	/**
+	 * @return the fixture type if the given interaction type (may be null!)
+	 */
+	def JvmType getFixtureType(InteractionType interactionType) {
+		return interactionType?.defaultMethod?.typeReference?.type
 	}
 
 }

--- a/rcp/org.testeditor.rcp4.views.teststepselection.tests/src/org/testeditor/rcp4/views/teststepselector/AmlModelTreeDropTextProviderTest.xtend
+++ b/rcp/org.testeditor.rcp4.views.teststepselection.tests/src/org/testeditor/rcp4/views/teststepselector/AmlModelTreeDropTextProviderTest.xtend
@@ -1,0 +1,23 @@
+package org.testeditor.rcp4.views.teststepselector
+
+import javax.inject.Inject
+import org.junit.Test
+import org.testeditor.aml.dsl.tests.AbstractTest
+import org.testeditor.aml.impl.AmlFactoryImpl
+
+class AmlModelTreeDropTextProviderTest extends AbstractTest {
+
+	@Inject AmlModelTreeDropTextProvider dropTextProvider
+	@Inject AmlFactoryImpl amlFactory
+
+	@Test
+	def void elementReplacementRestrictedToUiElementReferences() {
+		// when
+		val result = dropTextProvider.adjustTextBy(0, amlFactory.createComponentElement => [name = "Test"],
+			"<MyTest> <element> element <noelement> <lement>")
+
+		// then
+		assertEquals(result, "<MyTest> <Test> element <noelement> <lement>")
+	}
+
+}

--- a/rcp/org.testeditor.rcp4.views.teststepselection.tests/src/org/testeditor/rcp4/views/teststepselector/AmlModelTreeDropTextProviderTest.xtend
+++ b/rcp/org.testeditor.rcp4.views.teststepselection.tests/src/org/testeditor/rcp4/views/teststepselector/AmlModelTreeDropTextProviderTest.xtend
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2012 - 2016 Signal Iduna Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Signal Iduna Corporation - initial API and implementation
+ * akquinet AG
+ * itemis AG
+ *******************************************************************************/
 package org.testeditor.rcp4.views.teststepselector
 
 import javax.inject.Inject

--- a/rcp/org.testeditor.rcp4.views.teststepselection.tests/src/org/testeditor/rcp4/views/teststepselector/AmlModelTreeDropTextProviderTest.xtend
+++ b/rcp/org.testeditor.rcp4.views.teststepselection.tests/src/org/testeditor/rcp4/views/teststepselector/AmlModelTreeDropTextProviderTest.xtend
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
  * Contributors:
  * Signal Iduna Corporation - initial API and implementation
  * akquinet AG
@@ -24,9 +24,12 @@ class AmlModelTreeDropTextProviderTest extends AbstractTest {
 
 	@Test
 	def void elementReplacementRestrictedToUiElementReferences() {
+		// given
+		val componentElement = amlFactory.createComponentElement => [name = "Test"]
+		val replacementCandidates = "<MyTest> <element> element <noelement> <lement>"
+
 		// when
-		val result = dropTextProvider.adjustTextBy(0, amlFactory.createComponentElement => [name = "Test"],
-			"<MyTest> <element> element <noelement> <lement>")
+		val result = dropTextProvider.adjustTextBy(0, componentElement, replacementCandidates)
 
 		// then
 		assertEquals(result, "<MyTest> <Test> element <noelement> <lement>")

--- a/rcp/org.testeditor.rcp4.views.teststepselection/src/org/testeditor/rcp4/views/teststepselector/AmlModelTreeDropTextProvider.xtend
+++ b/rcp/org.testeditor.rcp4.views.teststepselection/src/org/testeditor/rcp4/views/teststepselector/AmlModelTreeDropTextProvider.xtend
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
  * Contributors:
  * Signal Iduna Corporation - initial API and implementation
  * akquinet AG
@@ -27,7 +27,7 @@ import org.testeditor.aml.InteractionType
 @Creatable
 class AmlModelTreeDropTextProvider {
 	def dispatch String adjustTextBy(int distance, ComponentElement element, String basis) {
-		basis.replace("element", element.name)
+		basis.replace("<element>", '''<«element.name»>''')
 	}
 
 	def dispatch String adjustTextBy(int distance, InteractionType element, String basis) {
@@ -35,7 +35,7 @@ class AmlModelTreeDropTextProvider {
 	}
 
 	def dispatch String adjustTextBy(int distance, Component element, String basis) {
-		(if(distance == 0) 'Mask: ' else '') + basis + (if(distance == 0) '\n' else '')
+		(if(distance == 0) 'Component: ' else '') + basis + (if(distance == 0) '\n' else '')
 	}
 
 	/** default, no adjustment */

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/AbstractTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/AbstractTest.xtend
@@ -23,30 +23,34 @@ import org.eclipse.xtext.junit4.XtextRunner
 import org.eclipse.xtext.junit4.validation.ValidationTestHelper
 import org.eclipse.xtext.util.Modules2
 import org.junit.runner.RunWith
+import org.mockito.MockitoAnnotations
 import org.testeditor.dsl.common.testing.AssertionHelper
 import org.testeditor.tcl.dsl.TclRuntimeModule
 import org.testeditor.tcl.dsl.TclStandaloneSetup
 
 @RunWith(XtextRunner)
 abstract class AbstractTest extends AbstractXtextTests {
-	
+
 	@Inject protected extension AssertionHelper
 	@Inject protected extension ValidationTestHelper
-	
+
 	override setUp() throws Exception {
 		super.setUp()
-		
+
 		// Setup dependency injection
 		val injector = createInjector
 		setInjector(injector)
 		injector.injectMembers(this)
+
+		// Setup mocking 
+		MockitoAnnotations.initMocks(this)
 	}
-	
+
 	protected def Injector createInjector() {
 		val modules = new ArrayList<Module>
 		modules += new TclRuntimeModule
 		modules.collectModules
-		
+
 		val mixinModule = Modules2.mixin(modules)
 		val setup = new TclStandaloneSetup {
 			override createInjector() {

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/validation/TclMissingFixtureValidatorTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/validation/TclMissingFixtureValidatorTest.xtend
@@ -1,0 +1,99 @@
+package org.testeditor.tcl.dsl.validation
+
+import org.eclipse.xtext.common.types.JvmOperation
+import org.eclipse.xtext.common.types.JvmParameterizedTypeReference
+import org.eclipse.xtext.common.types.JvmType
+import org.eclipse.xtext.validation.ValidationMessageAcceptor
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.testeditor.aml.AmlFactory
+import org.testeditor.aml.InteractionType
+import org.testeditor.aml.MethodReference
+import org.testeditor.aml.dsl.AmlStandaloneSetup
+import org.testeditor.aml.impl.AmlFactoryImpl
+import org.testeditor.tcl.dsl.tests.parser.AbstractParserTest
+import org.testeditor.tcl.util.TclModelUtil
+
+import static org.mockito.Matchers.*
+
+import static extension org.mockito.Mockito.*
+
+class TclMissingFixtureValidatorTest extends AbstractParserTest {
+
+	@Mock TclModelUtil tclModelUtil // injected into class under test
+	@InjectMocks TclValidator tclValidator // class under test
+	@Mock JvmParameterizedTypeReference typeReferenceMock
+	@Mock ValidationMessageAcceptor messageAcceptor
+
+	var AmlFactory amlFactory
+
+	val message = ArgumentCaptor.forClass(String)
+
+	@Before
+	override void setUp() {
+		super.setUp
+		MockitoAnnotations.initMocks(this)
+
+		val injector = (new AmlStandaloneSetup).createInjectorAndDoEMFRegistration
+		amlFactory = injector.getInstance(AmlFactoryImpl)
+
+		val operationMock = mock(JvmOperation)
+		val jvmTypeMock = mock(JvmType)
+		val interactionTypeMock = mock(InteractionType)
+		val methodReferenceMock = mock(MethodReference)
+
+		when(tclModelUtil.getInteraction(anyObject)).thenReturn(interactionTypeMock)
+		when(interactionTypeMock.defaultMethod).thenReturn(methodReferenceMock)
+		when(methodReferenceMock.operation).thenReturn(operationMock)
+		when(methodReferenceMock.typeReference).thenReturn(typeReferenceMock)
+		when(typeReferenceMock.type).thenReturn(jvmTypeMock)
+
+		val state = tclValidator.setMessageAcceptor(messageAcceptor)
+		state.state // needs to be called in order for internal state to be initialized. this again is necessary to allow messages to be issued on the "currentObject" of the validation
+	}
+
+	@Test
+	def void noInfoOnExistingFixture() {
+		// given
+		val tclFix = parse('''
+			package pa
+			# Test
+			
+			* first
+			Component: some_fantasy_component
+			- test step that maps
+		''')
+
+		// when
+		tclValidator.checkFixtureMethodForExistence(tclFix.steps.head.contexts.head.steps.head)
+
+		// then
+		messageAcceptor.verify(never).acceptInfo(anyString, anyObject, anyObject, anyInt, anyString)
+	}
+
+	@Test
+	def void infoOnMissingFixture() {
+		// given
+		val tclFix = parse('''
+			package pa
+			# Test
+			
+			* first
+			Component: some_fantasy_component
+			- test step that does not map
+		''')
+		when(typeReferenceMock.type).thenReturn(null)
+
+		// when
+		tclValidator.checkFixtureMethodForExistence(tclFix.steps.head.contexts.head.steps.head)
+
+		// then
+		messageAcceptor.verify.acceptInfo(message.capture, anyObject, anyObject, anyInt, anyString)
+		assertMatches(message.value, ".*could not resolve fixture")
+	}
+
+}

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/validation/TclMissingFixtureValidatorTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/validation/TclMissingFixtureValidatorTest.xtend
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2012 - 2016 Signal Iduna Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Signal Iduna Corporation - initial API and implementation
+ * akquinet AG
+ * itemis AG
+ *******************************************************************************/
 package org.testeditor.tcl.dsl.validation
 
 import org.eclipse.xtext.common.types.JvmOperation

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/validation/TclMissingFixtureValidatorTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/validation/TclMissingFixtureValidatorTest.xtend
@@ -62,9 +62,10 @@ class TclMissingFixtureValidatorTest extends AbstractParserTest {
 			Component: some_fantasy_component
 			- test step that maps
 		''')
+		val testStepThatMaps=tclFix.steps.head.contexts.head.steps.head
 
 		// when
-		tclValidator.checkFixtureMethodForExistence(tclFix.steps.head.contexts.head.steps.head)
+		tclValidator.checkFixtureMethodForExistence(testStepThatMaps)
 
 		// then
 		messageAcceptor.verify(never).acceptInfo(anyString, anyObject, anyObject, anyInt, anyString)

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
@@ -22,6 +22,7 @@ import org.eclipse.xtext.xbase.jvmmodel.AbstractModelInferrer
 import org.eclipse.xtext.xbase.jvmmodel.IJvmDeclaredTypeAcceptor
 import org.eclipse.xtext.xbase.jvmmodel.JvmTypesBuilder
 import org.testeditor.aml.InteractionType
+import org.testeditor.aml.ModelUtil
 import org.testeditor.tcl.AssertionTestStep
 import org.testeditor.tcl.SpecificationStepImplementation
 import org.testeditor.tcl.StepContentElement
@@ -40,6 +41,7 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 	@Inject extension TclModelUtil
 	@Inject TclAssertCallBuilder assertCallBuilder
 	@Inject IQualifiedNameProvider nameProvider
+	@Inject ModelUtil amlModelUtil
 
 	def dispatch void infer(TclModel model, IJvmDeclaredTypeAcceptor acceptor, boolean isPreIndexingPhase) {
 		model.test?.infer(acceptor, isPreIndexingPhase)
@@ -91,10 +93,10 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 	 * @return all {@link JvmType} of all fixtures that are referenced.
 	 */
 	private def Set<JvmType> getFixtureTypes(TestCase test) {
-		val components = test.steps.map[contexts].flatten.map[component]
+		val components = test.steps.map[contexts].flatten.map[component].filterNull
 		// TODO the part from here should go somewhere in Aml ModelUtil
-		val interactionTypes = components.map[type?.interactionTypes].filterNull.flatten.toSet
-		val fixtureTypes = interactionTypes.map[defaultMethod?.typeReference?.type].filterNull.toSet
+		val interactionTypes = components.map[amlModelUtil.getAllInteractionTypes(it)].flatten.toSet
+		val fixtureTypes = interactionTypes.map[amlModelUtil.getFixtureType(it)].filterNull.toSet
 		return fixtureTypes
 	}
 


### PR DESCRIPTION
* fix missing validation for unresolvable fixtures
* fix drag'n'drop from test step selector having "element" in template
  string
* fix missing fixture instance var during generation