### PR TITLE
Downgrade to Java 1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,26 @@ test-editor-xtext
 [![License](http://img.shields.io/badge/license-EPL-blue.svg?style=flat)](https://www.eclipse.org/legal/epl-v10.html)
 [![Build Status](https://travis-ci.org/test-editor/test-editor-xtext.svg?branch=develop)](https://travis-ci.org/test-editor/test-editor-xtext)
 
-An Xtext based editor to define the mapping between the test-editor and the application under test (AUT).
+An Xtext based editor to specify domain-driven acceptance tests.
 
-This sub-project is called "aml" for Application (Under Test) Mapping Language.
+## Users
 
+The latest released version can be found on [bintray](https://bintray.com/test-editor/test-editor/testeditor-app).
 
-A simple Eclipse IDE with the AML included can be downloaded 
-[here](https://ci.testeditor.org/job/Test-Editor-AML-Product/lastSuccessfulBuild/artifact/rcp/org.testeditor.aml.rcp.product/target/products/).
+The latest development version can be downloaded [here](https://ci.testeditor.org/job/Test-Editor-AML-Product/lastSuccessfulBuild/artifact/rcp/org.testeditor.aml.rcp.product/target/products/).
 
-To install AML into your existing Eclipse installation the SNAPSHOT update site can be found [here](https://ci.testeditor.org/job/Test-Editor-AML-Product/lastSuccessfulBuild/artifact/rcp/org.testeditor.aml.rcp.updatesite/target/site/).
+## Developers
+
+After checking out the source code we first need to build the Eclipse target platform:
+
+    mvn clean install -f "releng/org.testeditor.aml.releng.target/pom.xml" 
+    
+This will take some time for the first run but should be fast afterwards.
+
+After building the target platform, we can simply build the test editor with:
+
+    mvn clean install
+
+For building the full RCP product we simply add the Maven profile "`product`":
+
+    mvn clean install -Pproduct

--- a/aml/org.testeditor.aml.dsl.ide/.classpath
+++ b/aml/org.testeditor.aml.dsl.ide/.classpath
@@ -12,6 +12,6 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/aml/org.testeditor.aml.dsl.ide/.settings/org.eclipse.jdt.core.prefs
+++ b/aml/org.testeditor.aml.dsl.ide/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=1.7

--- a/aml/org.testeditor.aml.dsl.ide/META-INF/MANIFEST.MF
+++ b/aml/org.testeditor.aml.dsl.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.testeditor.aml.dsl.ide
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.testeditor.aml.dsl.ide.contentassist.antlr.internal,
  org.testeditor.aml.dsl.ide.contentassist.antlr
 Require-Bundle: org.testeditor.aml.dsl,

--- a/aml/org.testeditor.aml.dsl.tests/META-INF/MANIFEST.MF
+++ b/aml/org.testeditor.aml.dsl.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: Signal Iduna Corporation
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: org.testeditor.aml.dsl.tests;singleton:=true
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xtext.junit4,
  org.eclipse.xtext.xbase.lib,

--- a/aml/org.testeditor.aml.dsl.ui.tests/.classpath
+++ b/aml/org.testeditor.aml.dsl.ui.tests/.classpath
@@ -7,6 +7,6 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/aml/org.testeditor.aml.dsl.ui.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/aml/org.testeditor.aml.dsl.ui.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=1.7

--- a/aml/org.testeditor.aml.dsl.ui.tests/META-INF/MANIFEST.MF
+++ b/aml/org.testeditor.aml.dsl.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.testeditor.aml.dsl.ui.tests
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.workbench;resolution:=optional,
  com.google.guava,

--- a/aml/org.testeditor.aml.dsl.ui/META-INF/MANIFEST.MF
+++ b/aml/org.testeditor.aml.dsl.ui/META-INF/MANIFEST.MF
@@ -28,7 +28,7 @@ Require-Bundle: org.testeditor.aml.dsl,
  org.eclipse.xtend.lib;resolution:=optional,
  org.testeditor.aml.dsl.ide
 Import-Package: org.apache.log4j
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.testeditor.aml.dsl.ui,
  org.testeditor.aml.dsl.ui.contentassist,
  org.testeditor.aml.dsl.ui.highlighting,

--- a/aml/org.testeditor.aml.dsl/META-INF/MANIFEST.MF
+++ b/aml/org.testeditor.aml.dsl/META-INF/MANIFEST.MF
@@ -20,7 +20,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.osgi,
  org.eclipse.xtend.lib
 Import-Package: org.apache.log4j
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.testeditor.aml.dsl,
  org.testeditor.aml.dsl.formatting2,
  org.testeditor.aml.dsl.generator,

--- a/aml/org.testeditor.aml.model/META-INF/MANIFEST.MF
+++ b/aml/org.testeditor.aml.model/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.testeditor.aml,
  org.testeditor.aml.impl,
  org.testeditor.aml.util

--- a/common/org.testeditor.dsl.common.testing/META-INF/MANIFEST.MF
+++ b/common/org.testeditor.dsl.common.testing/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.testeditor.dsl.common.testing
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xtext.junit4,
  org.eclipse.xtext.xbase.lib,

--- a/common/org.testeditor.dsl.common.tests/.classpath
+++ b/common/org.testeditor.dsl.common.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>

--- a/common/org.testeditor.dsl.common.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/common/org.testeditor.dsl.common.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=1.7

--- a/common/org.testeditor.dsl.common.tests/META-INF/MANIFEST.MF
+++ b/common/org.testeditor.dsl.common.tests/META-INF/MANIFEST.MF
@@ -5,5 +5,5 @@ Bundle-SymbolicName: org.testeditor.dsl.common.tests
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Signal Iduna Corporation
 Fragment-Host: org.testeditor.dsl.common;bundle-version="1.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/common/org.testeditor.dsl.common.ui.tests/.classpath
+++ b/common/org.testeditor.dsl.common.ui.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>

--- a/common/org.testeditor.dsl.common.ui.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/common/org.testeditor.dsl.common.ui.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=1.7

--- a/common/org.testeditor.dsl.common.ui.tests/META-INF/MANIFEST.MF
+++ b/common/org.testeditor.dsl.common.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Tests
 Bundle-SymbolicName: org.testeditor.dsl.common.ui.tests
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Signal Iduna Corporation
 Require-Bundle: com.google.guava,
  org.eclipse.xtext.xbase.lib,

--- a/common/org.testeditor.dsl.common.ui/.classpath
+++ b/common/org.testeditor.dsl.common.ui/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>

--- a/common/org.testeditor.dsl.common.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/common/org.testeditor.dsl.common.ui/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=1.7

--- a/common/org.testeditor.dsl.common.ui/META-INF/MANIFEST.MF
+++ b/common/org.testeditor.dsl.common.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Ui
 Bundle-SymbolicName: org.testeditor.dsl.common.ui;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Signal Iduna Corporation
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: com.google.guava,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtend.lib,

--- a/common/org.testeditor.dsl.common/.classpath
+++ b/common/org.testeditor.dsl.common/.classpath
@@ -7,6 +7,6 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/common/org.testeditor.dsl.common/.settings/org.eclipse.jdt.core.prefs
+++ b/common/org.testeditor.dsl.common/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=1.7

--- a/common/org.testeditor.dsl.common/META-INF/MANIFEST.MF
+++ b/common/org.testeditor.dsl.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.testeditor.dsl.common
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: com.google.guava,
  org.eclipse.core.resources,
  org.eclipse.xtext.xbase.lib,

--- a/common/org.testeditor.dsl.common/src/org/testeditor/dsl/common/ide/util/ProjectContentGenerator.xtend
+++ b/common/org.testeditor.dsl.common/src/org/testeditor/dsl/common/ide/util/ProjectContentGenerator.xtend
@@ -249,7 +249,7 @@ class ProjectContentGenerator {
 			
 				<properties>
 					<!-- Version definitions below -->
-					<java.version>1.8</java.version>
+					<java.version>1.7</java.version>
 					<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 			
 					<maven-clean-plugin.version>2.5</maven-clean-plugin.version>
@@ -432,7 +432,7 @@ class ProjectContentGenerator {
 						<plugin>
 						    <groupId>org.codehaus.mojo</groupId>
 						    <artifactId>build-helper-maven-plugin</artifactId>
-						    <version>1.8</version>
+						    <version>1.7</version>
 						    <executions>
 						        <execution>
 						            <id>add-test-source</id>

--- a/demo/swing-demo/pom.xml
+++ b/demo/swing-demo/pom.xml
@@ -9,7 +9,7 @@
 
 	<properties>
 		<!-- Version definitions below -->
-		<java.version>1.8</java.version>
+		<java.version>1.7</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<maven-clean-plugin.version>2.5</maven-clean-plugin.version>

--- a/legacy/org.testeditor.aml.legacy.importer.ui/META-INF/MANIFEST.MF
+++ b/legacy/org.testeditor.aml.legacy.importer.ui/META-INF/MANIFEST.MF
@@ -15,7 +15,7 @@ Require-Bundle: org.eclipse.ui,
  org.testeditor.aml.dsl.ui,
  org.testeditor.aml.model,
  org.testeditor.aml.legacy.model
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Signal Iduna Corporation
 

--- a/legacy/org.testeditor.aml.legacy.model/META-INF/MANIFEST.MF
+++ b/legacy/org.testeditor.aml.legacy.model/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: org.testeditor.aml.dsl.legacy.model
 Bundle-SymbolicName: org.testeditor.aml.legacy.model
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Signal Iduna Corporation
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.xtend.lib,
  org.eclipse.xtend.lib.macro,
  com.google.guava,

--- a/rcp/org.testeditor.rcp.product/testeditor.product
+++ b/rcp/org.testeditor.rcp.product/testeditor.product
@@ -23,7 +23,7 @@
    </launcher>
 
    <vm>
-      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8</windows>
+      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7</windows>
    </vm>
 
    <plugins>

--- a/rcp/org.testeditor.rcp/.classpath
+++ b/rcp/org.testeditor.rcp/.classpath
@@ -7,6 +7,6 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/rcp/org.testeditor.rcp/.settings/org.eclipse.jdt.core.prefs
+++ b/rcp/org.testeditor.rcp/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=1.7

--- a/rcp/org.testeditor.rcp/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtend.lib,
  org.eclipse.xtend.lib.macro
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.core.resources,
  org.eclipse.jdt.core,

--- a/rcp/org.testeditor.rcp4.product/testeditor.product
+++ b/rcp/org.testeditor.rcp4.product/testeditor.product
@@ -29,7 +29,7 @@
 
 
    <vm>
-      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8</windows>
+      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7</windows>
    </vm>
 
 

--- a/rcp/org.testeditor.rcp4.tcltestrun/.classpath
+++ b/rcp/org.testeditor.rcp4.tcltestrun/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>

--- a/rcp/org.testeditor.rcp4.tcltestrun/.settings/org.eclipse.jdt.core.prefs
+++ b/rcp/org.testeditor.rcp4.tcltestrun/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=1.7

--- a/rcp/org.testeditor.rcp4.tcltestrun/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.tcltestrun/META-INF/MANIFEST.MF
@@ -11,6 +11,6 @@ Require-Bundle: org.eclipse.xtend.lib,
  org.testeditor.dsl.common.ui;bundle-version="1.0.0",
  org.eclipse.m2e.maven.runtime;bundle-version="1.6.2",
  org.eclipse.m2e.core;bundle-version="1.6.2"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.testeditor.rcp4.tcltestrun
 Bundle-ActivationPolicy: lazy

--- a/rcp/org.testeditor.rcp4.tests/.classpath
+++ b/rcp/org.testeditor.rcp4.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/rcp/org.testeditor.rcp4.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/rcp/org.testeditor.rcp4.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=1.7

--- a/rcp/org.testeditor.rcp4.tests/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Integration Tests of the rcp4
 Bundle-SymbolicName: org.testeditor.rcp4.tests
 Bundle-Version: 1.0.0.qualifier
 Fragment-Host: org.testeditor.rcp4;bundle-version="1.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.testeditor.dsl.common.testing;bundle-version="1.0.0",
  org.junit
 Import-Package: org.eclipse.ui

--- a/rcp/org.testeditor.rcp4.uatests/.classpath
+++ b/rcp/org.testeditor.rcp4.uatests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/test/java"/>
 	<classpathentry kind="src" path="src/main/java"/>

--- a/rcp/org.testeditor.rcp4.uatests/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.uatests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: User Acceptance Tests
 Bundle-SymbolicName: org.testeditor.rcp4.uatests
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.swtbot.eclipse.finder;bundle-version="2.3.0",
  org.junit;bundle-version="4.12.0",
  org.eclipse.swt;bundle-version="3.104.1",

--- a/rcp/org.testeditor.rcp4.views.projectexplorer/.classpath
+++ b/rcp/org.testeditor.rcp4.views.projectexplorer/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>

--- a/rcp/org.testeditor.rcp4.views.projectexplorer/.settings/org.eclipse.jdt.core.prefs
+++ b/rcp/org.testeditor.rcp4.views.projectexplorer/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=1.7

--- a/rcp/org.testeditor.rcp4.views.projectexplorer/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.views.projectexplorer/META-INF/MANIFEST.MF
@@ -12,4 +12,4 @@ Require-Bundle: org.eclipse.ui.navigator;bundle-version="3.6.0",
  org.eclipse.jface;bundle-version="3.11.0",
  org.eclipse.jdt.core;bundle-version="3.11.1",
  org.eclipse.ui.workbench;bundle-version="3.107.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/rcp/org.testeditor.rcp4.views.tcltestrun/.classpath
+++ b/rcp/org.testeditor.rcp4.views.tcltestrun/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>

--- a/rcp/org.testeditor.rcp4.views.tcltestrun/.settings/org.eclipse.jdt.core.prefs
+++ b/rcp/org.testeditor.rcp4.views.tcltestrun/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=1.7

--- a/rcp/org.testeditor.rcp4.views.tcltestrun/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.views.tcltestrun/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: TcltestrunUi
 Bundle-SymbolicName: org.testeditor.rcp4.views.tcltestrun;singleton:=true
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.testeditor.tcl.dsl.ui,
  org.testeditor.rcp4.tcltestrun,
  org.eclipse.jdt.junit,

--- a/rcp/org.testeditor.rcp4.views.teststepselection.tests/.classpath
+++ b/rcp/org.testeditor.rcp4.views.teststepselection.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>

--- a/rcp/org.testeditor.rcp4.views.teststepselection.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/rcp/org.testeditor.rcp4.views.teststepselection.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=1.7

--- a/rcp/org.testeditor.rcp4.views.teststepselection.tests/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.views.teststepselection.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: org.testeditor.rcp4.views.teststepselector.tests
 Bundle-SymbolicName: org.testeditor.rcp4.views.teststepselector.tests;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Signal Iduna Corporation
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xtext.xbase.lib,

--- a/rcp/org.testeditor.rcp4.views.teststepselection/.classpath
+++ b/rcp/org.testeditor.rcp4.views.teststepselection/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>

--- a/rcp/org.testeditor.rcp4.views.teststepselection/.settings/org.eclipse.jdt.core.prefs
+++ b/rcp/org.testeditor.rcp4.views.teststepselection/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=1.7

--- a/rcp/org.testeditor.rcp4.views.teststepselection/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.views.teststepselection/META-INF/MANIFEST.MF
@@ -30,7 +30,7 @@ Require-Bundle: com.google.guava,
  org.eclipse.e4.core.di,
  org.eclipse.emf.ecore,
  org.testeditor.logging
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.google.inject,
  javax.inject;version="1.0.0",
  org.eclipse.e4.core.di,

--- a/rcp/org.testeditor.rcp4.views.testview/.classpath
+++ b/rcp/org.testeditor.rcp4.views.testview/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>

--- a/rcp/org.testeditor.rcp4.views.testview/.settings/org.eclipse.jdt.core.prefs
+++ b/rcp/org.testeditor.rcp4.views.testview/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=1.7

--- a/rcp/org.testeditor.rcp4.views.testview/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.views.testview/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.xtend.lib,
  org.eclipse.xtend.lib.macro,
  org.eclipse.e4.core.services
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: javax.inject,
  org.eclipse.e4.core.di.annotations,
  org.eclipse.e4.core.di.extensions,

--- a/rcp/org.testeditor.rcp4/.classpath
+++ b/rcp/org.testeditor.rcp4/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>

--- a/rcp/org.testeditor.rcp4/.settings/org.eclipse.jdt.core.prefs
+++ b/rcp/org.testeditor.rcp4/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=1.7

--- a/rcp/org.testeditor.rcp4/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.eclipse.core.runtime,
  com.gradleware.tooling.utils;bundle-version="0.10.0",
  org.eclipse.ui.net;bundle-version="1.2.200",
  org.eclipse.core.net;bundle-version="1.2.300"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.core.resources,
  org.eclipse.e4.core.di,

--- a/releng/org.testeditor.aml.releng.parent/pom.xml
+++ b/releng/org.testeditor.aml.releng.parent/pom.xml
@@ -10,7 +10,7 @@
 
 	<properties>
 		<!-- Version definitions below -->
-		<java.version>1.8</java.version>
+		<java.version>1.7</java.version>
 		<xtext.version>2.9.0</xtext.version>
 		<xtend.version>${xtext.version}</xtend.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tcl/org.testeditor.tcl.dsl.ide/.classpath
+++ b/tcl/org.testeditor.tcl.dsl.ide/.classpath
@@ -8,6 +8,6 @@
 	</classpathentry>
 	<classpathentry excluding=".gitignore" kind="src" path="xtend-gen"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/tcl/org.testeditor.tcl.dsl.ide/.settings/org.eclipse.jdt.core.prefs
+++ b/tcl/org.testeditor.tcl.dsl.ide/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=1.7

--- a/tcl/org.testeditor.tcl.dsl.ide/META-INF/MANIFEST.MF
+++ b/tcl/org.testeditor.tcl.dsl.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.testeditor.tcl.dsl.ide
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.testeditor.tcl.dsl.ide.contentassist.antlr,
  org.testeditor.tcl.dsl.ide.contentassist.antlr.internal,
  org.testeditor.tcl.dsl.ide.highlighting

--- a/tcl/org.testeditor.tcl.dsl.tests/.classpath
+++ b/tcl/org.testeditor.tcl.dsl.tests/.classpath
@@ -12,6 +12,6 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/tcl/org.testeditor.tcl.dsl.tests/META-INF/MANIFEST.MF
+++ b/tcl/org.testeditor.tcl.dsl.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: Signal Iduna Corporation
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: org.testeditor.tcl.dsl.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xtext.junit4,
  org.eclipse.xtext.xbase.lib,

--- a/tcl/org.testeditor.tcl.dsl.ui.tests/.classpath
+++ b/tcl/org.testeditor.tcl.dsl.ui.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>

--- a/tcl/org.testeditor.tcl.dsl.ui.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/tcl/org.testeditor.tcl.dsl.ui.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=1.7

--- a/tcl/org.testeditor.tcl.dsl.ui.tests/META-INF/MANIFEST.MF
+++ b/tcl/org.testeditor.tcl.dsl.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.tcl.dsl.ui.tests
 Bundle-SymbolicName: org.testeditor.tcl.dsl.ui.tests
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Fragment-Host: org.testeditor.tcl.dsl.ui
 Require-Bundle: com.google.guava,
  org.eclipse.xtext.xbase.lib,

--- a/tcl/org.testeditor.tcl.dsl.ui/META-INF/MANIFEST.MF
+++ b/tcl/org.testeditor.tcl.dsl.ui/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: Signal Iduna Corporation
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: org.testeditor.tcl.dsl.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.testeditor.dsl.common,
  org.testeditor.tcl.dsl;visibility:=reexport,
  org.testeditor.tcl.dsl.ide,
@@ -28,11 +28,11 @@ Require-Bundle: org.testeditor.dsl.common,
  org.eclipse.xpand,
  org.eclipse.xtend.lib;resolution:=optional,
  org.eclipse.jdt.core,
- org.eclipse.jdt.junit;bundle-version="3.8.0",
- org.slf4j.api
+ org.eclipse.jdt.junit;bundle-version="3.8.0"
 Import-Package: org.apache.log4j,
  org.eclipse.jdt.core,
- org.eclipse.jdt.junit.launcher
+ org.eclipse.jdt.junit.launcher,
+ org.slf4j
 Export-Package: org.testeditor.tcl.dsl.ui,
  org.testeditor.tcl.dsl.ui.contentassist,
  org.testeditor.tcl.dsl.ui.internal,

--- a/tcl/org.testeditor.tcl.dsl/META-INF/MANIFEST.MF
+++ b/tcl/org.testeditor.tcl.dsl/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.testeditor.tcl.model;visibility:=reexport,
  org.eclipse.xtend.lib
 Import-Package: org.apache.log4j
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.testeditor.tcl.dsl,
  org.testeditor.tcl.dsl.formatting2,
  org.testeditor.tcl.dsl.jvmmodel,

--- a/tcl/org.testeditor.tcl.model/META-INF/MANIFEST.MF
+++ b/tcl/org.testeditor.tcl.model/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Signal Iduna Corporation
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.testeditor.tcl,
  org.testeditor.tcl.impl,
  org.testeditor.tcl.util

--- a/tsl/org.testeditor.tsl.dsl.ide/.classpath
+++ b/tsl/org.testeditor.tsl.dsl.ide/.classpath
@@ -12,6 +12,6 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/tsl/org.testeditor.tsl.dsl.ide/.settings/org.eclipse.jdt.core.prefs
+++ b/tsl/org.testeditor.tsl.dsl.ide/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=1.7

--- a/tsl/org.testeditor.tsl.dsl.ide/META-INF/MANIFEST.MF
+++ b/tsl/org.testeditor.tsl.dsl.ide/META-INF/MANIFEST.MF
@@ -10,4 +10,4 @@ Require-Bundle: org.testeditor.tsl.dsl,
  org.eclipse.xtext.xbase.ide
 Export-Package: org.testeditor.tsl.dsl.ide.contentassist.antlr,
  org.testeditor.tsl.dsl.ide.contentassist.antlr.internal
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/tsl/org.testeditor.tsl.dsl.tests/META-INF/MANIFEST.MF
+++ b/tsl/org.testeditor.tsl.dsl.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: Signal Iduna Corporation
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: org.testeditor.tsl.dsl.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.testeditor.tsl.dsl,
  org.testeditor.tsl.dsl.ui,
  org.eclipse.core.runtime,

--- a/tsl/org.testeditor.tsl.dsl.ui/META-INF/MANIFEST.MF
+++ b/tsl/org.testeditor.tsl.dsl.ui/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: Signal Iduna Corporation
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: org.testeditor.tsl.dsl.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.testeditor.tsl.dsl;visibility:=reexport,
  org.eclipse.xtext.ui,
  org.eclipse.ui.editors;bundle-version="3.5.0",

--- a/tsl/org.testeditor.tsl.dsl.web/.classpath
+++ b/tsl/org.testeditor.tsl.dsl.web/.classpath
@@ -21,7 +21,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/tsl/org.testeditor.tsl.dsl.web/.settings/org.eclipse.jdt.core.prefs
+++ b/tsl/org.testeditor.tsl.dsl.web/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=1.7

--- a/tsl/org.testeditor.tsl.dsl.web/.settings/org.eclipse.wst.common.project.facet.core.xml
+++ b/tsl/org.testeditor.tsl.dsl.web/.settings/org.eclipse.wst.common.project.facet.core.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <faceted-project>
   <fixed facet="wst.jsdt.web"/>
-  <installed facet="java" version="1.8"/>
+  <installed facet="java" version="1.7"/>
   <installed facet="jst.web" version="3.1"/>
   <installed facet="wst.jsdt.web" version="1.0"/>
 </faceted-project>

--- a/tsl/org.testeditor.tsl.dsl/META-INF/MANIFEST.MF
+++ b/tsl/org.testeditor.tsl.dsl/META-INF/MANIFEST.MF
@@ -17,7 +17,7 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.testeditor.tsl.model;visibility:=reexport,
  org.eclipse.xtend.lib
 Import-Package: org.apache.log4j
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.testeditor.tsl.dsl,
  org.testeditor.tsl.dsl.formatting2,
  org.testeditor.tsl.dsl.generator,

--- a/tsl/org.testeditor.tsl.model/META-INF/MANIFEST.MF
+++ b/tsl/org.testeditor.tsl.model/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Signal Iduna Corporation
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.testeditor.tsl,
  org.testeditor.tsl.impl,
  org.testeditor.tsl.util


### PR DESCRIPTION
Seems like we need to downgrade to Java 1.7 for the meantime until all our potential users have Java 1.8.

No code changes are required for this - Xtend happily compiles to 1.7 code.