### PR TITLE
Speed up build

### DIFF
--- a/aml/org.testeditor.aml.model/pom.xml
+++ b/aml/org.testeditor.aml.model/pom.xml
@@ -46,7 +46,7 @@
 						</execution>
 					</executions>
 					<configuration>
-						<failOnValidationError>true</failOnValidationError>
+                        <classPathLookupFilter>.*(ecore|genmodel|xcore|xtext).*</classPathLookupFilter>
 						<languages>
 							<language>
 								<setup>org.eclipse.xtext.ecore.EcoreSupport</setup>

--- a/aml/org.testeditor.aml.model/pom.xml
+++ b/aml/org.testeditor.aml.model/pom.xml
@@ -46,7 +46,7 @@
 						</execution>
 					</executions>
 					<configuration>
-                        <classPathLookupFilter>.*(ecore|genmodel|xcore|xtext).*</classPathLookupFilter>
+						<classPathLookupFilter>.*(ecore|genmodel|xcore|xtext).*</classPathLookupFilter>
 						<languages>
 							<language>
 								<setup>org.eclipse.xtext.ecore.EcoreSupport</setup>

--- a/rcp/org.testeditor.rcp4.uatests/pom.xml
+++ b/rcp/org.testeditor.rcp4.uatests/pom.xml
@@ -98,7 +98,7 @@
 						</execution>
 					</executions>
 					<configuration>
-                        <classPathLookupFilter>.*(tsl|tml|tcl|aml).*</classPathLookupFilter>
+						<classPathLookupFilter>.*(tsl|tml|tcl|aml).*</classPathLookupFilter>
 						<languages>
 							<language>
 								<setup>org.testeditor.tsl.dsl.TslStandaloneSetup</setup>

--- a/rcp/org.testeditor.rcp4.uatests/pom.xml
+++ b/rcp/org.testeditor.rcp4.uatests/pom.xml
@@ -98,6 +98,7 @@
 						</execution>
 					</executions>
 					<configuration>
+                        <classPathLookupFilter>.*(tsl|tml|tcl|aml).*</classPathLookupFilter>
 						<languages>
 							<language>
 								<setup>org.testeditor.tsl.dsl.TslStandaloneSetup</setup>

--- a/tcl/org.testeditor.tcl.model/pom.xml
+++ b/tcl/org.testeditor.tcl.model/pom.xml
@@ -46,7 +46,7 @@
 						</execution>
 					</executions>
 					<configuration>
-						<failOnValidationError>true</failOnValidationError>
+                        <classPathLookupFilter>.*(ecore|genmodel|xcore|xtext).*</classPathLookupFilter>
 						<languages>
 							<language>
 								<setup>org.eclipse.xtext.ecore.EcoreSupport</setup>

--- a/tcl/org.testeditor.tcl.model/pom.xml
+++ b/tcl/org.testeditor.tcl.model/pom.xml
@@ -46,7 +46,7 @@
 						</execution>
 					</executions>
 					<configuration>
-                        <classPathLookupFilter>.*(ecore|genmodel|xcore|xtext).*</classPathLookupFilter>
+						<classPathLookupFilter>.*(ecore|genmodel|xcore|xtext).*</classPathLookupFilter>
 						<languages>
 							<language>
 								<setup>org.eclipse.xtext.ecore.EcoreSupport</setup>

--- a/tml/org.testeditor.tml.model/pom.xml
+++ b/tml/org.testeditor.tml.model/pom.xml
@@ -46,7 +46,7 @@
 						</execution>
 					</executions>
 					<configuration>
-						<failOnValidationError>true</failOnValidationError>
+                        <classPathLookupFilter>.*(ecore|genmodel|xcore|xtext).*</classPathLookupFilter>
 						<languages>
 							<language>
 								<setup>org.eclipse.xtext.ecore.EcoreSupport</setup>

--- a/tml/org.testeditor.tml.model/pom.xml
+++ b/tml/org.testeditor.tml.model/pom.xml
@@ -46,7 +46,7 @@
 						</execution>
 					</executions>
 					<configuration>
-                        <classPathLookupFilter>.*(ecore|genmodel|xcore|xtext).*</classPathLookupFilter>
+						<classPathLookupFilter>.*(ecore|genmodel|xcore|xtext).*</classPathLookupFilter>
 						<languages>
 							<language>
 								<setup>org.eclipse.xtext.ecore.EcoreSupport</setup>

--- a/tsl/org.testeditor.tsl.model/pom.xml
+++ b/tsl/org.testeditor.tsl.model/pom.xml
@@ -46,7 +46,7 @@
 						</execution>
 					</executions>
 					<configuration>
-						<failOnValidationError>true</failOnValidationError>
+                        <classPathLookupFilter>.*(ecore|genmodel|xcore|xtext).*</classPathLookupFilter>
 						<languages>
 							<language>
 								<setup>org.eclipse.xtext.ecore.EcoreSupport</setup>

--- a/tsl/org.testeditor.tsl.model/pom.xml
+++ b/tsl/org.testeditor.tsl.model/pom.xml
@@ -46,7 +46,7 @@
 						</execution>
 					</executions>
 					<configuration>
-                        <classPathLookupFilter>.*(ecore|genmodel|xcore|xtext).*</classPathLookupFilter>
+						<classPathLookupFilter>.*(ecore|genmodel|xcore|xtext).*</classPathLookupFilter>
 						<languages>
 							<language>
 								<setup>org.eclipse.xtext.ecore.EcoreSupport</setup>


### PR DESCRIPTION
Specifying `classPathLookupFilter` when using `xtext-maven-plugin` speeds up the build.
On my machine the build runs in 2:58 instead of 3:30 (without tests).

Also remove `<failOnValidationError>true</failOnValidationError>` as this is the default value and doesn't need to be specified.