### PR TITLE
Improve release process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,7 +123,7 @@ void postRelease(String preReleaseVersion) {
         def developVersion = getCurrentVersion()
         if (developVersion == preReleaseVersion) {
             sh "git merge origin/master"
-            def nextSnapshotVersion = '\\${parsedVersion.majorVersion}.\\${parsedVersion.minorVersion}.\\${parsedVersion.nextIncrementalVersion}-SNAPSHOT'
+            def nextSnapshotVersion = '\\${parsedVersion.majorVersion}.\\${parsedVersion.nextMinorVersion}.0-SNAPSHOT'
             setVersion(nextSnapshotVersion, 'releng/org.testeditor.releng.target/pom.xml', 'org.testeditor.releng.target.parent')
             setVersion(nextSnapshotVersion, 'pom.xml', 'org.testeditor.releng.parent')
             sh "git add *"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,6 +118,7 @@ void postRelease(String preReleaseVersion) {
 
     stage 'Increment develop version'
         sh "git checkout develop"
+        sh "git fetch origin"
         sh "git reset --hard origin/develop"
         def developVersion = getCurrentVersion()
         if (developVersion == preReleaseVersion) {


### PR DESCRIPTION
If a PR is merged before the release is completed we need to fetch from the remote before incrementing the develop version.