### PR TITLE
TE-396 aml pretty print

### DIFF
--- a/aml/org.testeditor.aml.dsl.tests/src/org/testeditor/aml/dsl/tests/formatter/AmlModelFormatterTest.xtend
+++ b/aml/org.testeditor.aml.dsl.tests/src/org/testeditor/aml/dsl/tests/formatter/AmlModelFormatterTest.xtend
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
  * Contributors:
  * Signal Iduna Corporation - initial API and implementation
  * akquinet AG
@@ -24,7 +24,7 @@ class AmlModelFormatterTest extends AbstractFormatterTest {
 
 	@Test
 	def void formatElementsAndBrackets() {
-		formatterTester.assertFormatted[
+		formatterTester.assertFormatted [
 			expectation = '''
 				package com.example
 				
@@ -45,7 +45,7 @@ class AmlModelFormatterTest extends AbstractFormatterTest {
 			'''
 		]
 	}
-	
+
 	@Test
 	def void formatSpaces() {
 		assertFormatted[
@@ -64,7 +64,34 @@ class AmlModelFormatterTest extends AbstractFormatterTest {
 				 interaction 	type  MyInteractionType   { }
 				component MyDialog    is	Dialog {  label  = 	"myLabel" }
 			'''
-		]		
+		]
+	}
+
+	@Test
+	def void formatImports() {
+		assertFormatted[
+			expectation = '''
+				import selenide.*
+				import selenide.LocatorStrategy
+				
+				component type Test
+			'''
+			toBeFormatted = expectation
+		]
+		assertFormatted[
+			expectation = '''
+				import selenide.*
+				import selenide.LocatorStrategy
+				
+				component type Test
+			'''
+			toBeFormatted = '''
+				import selenide.*
+					import selenide.LocatorStrategy
+					
+				component type Test
+			'''
+		]
 	}
 
 }

--- a/aml/org.testeditor.aml.dsl.tests/src/org/testeditor/aml/dsl/tests/formatter/ComponentFormatterTest.xtend
+++ b/aml/org.testeditor.aml.dsl.tests/src/org/testeditor/aml/dsl/tests/formatter/ComponentFormatterTest.xtend
@@ -40,4 +40,55 @@ class ComponentFormatterTest extends AbstractFormatterTest {
 		]
 	}
 	
+	@Test
+	def void formatComponent() {
+		// if there is a single line between elements leave as it is
+		assertFormatted[
+			expectation = '''
+				component LoginPage is WebPage {
+				
+					element User is Text {
+
+					}
+				
+				}
+			'''
+			toBeFormatted = expectation
+		]
+		// if the uses chooses to not put in empty lines, leave as it is
+		assertFormatted[
+			expectation = '''
+				component LoginPage is WebPage {
+					element User is Text {
+					}
+				}
+			'''
+			toBeFormatted = expectation
+		]
+		// if there is more than one empty line, format as just one empty line in-between
+		assertFormatted[
+			expectation = '''
+				component LoginPage is WebPage {
+				
+					element User is Text {
+
+					}
+				
+				}
+			'''
+			toBeFormatted = '''
+				component LoginPage is WebPage {
+					
+					
+					element User is Text {
+						
+						
+					}
+					
+					
+				}
+			'''
+		]
+	}
+	
 }

--- a/aml/org.testeditor.aml.dsl.tests/src/org/testeditor/aml/dsl/tests/formatter/ComponentFormatterTest.xtend
+++ b/aml/org.testeditor.aml.dsl.tests/src/org/testeditor/aml/dsl/tests/formatter/ComponentFormatterTest.xtend
@@ -55,7 +55,7 @@ class ComponentFormatterTest extends AbstractFormatterTest {
 			'''
 			toBeFormatted = expectation
 		]
-		// if the uses chooses to not put in empty lines, leave as it is
+		// if the user chooses to not put in empty lines, leave as it is
 		assertFormatted[
 			expectation = '''
 				component LoginPage is WebPage {

--- a/aml/org.testeditor.aml.dsl/src/org/testeditor/aml/dsl/formatting2/AmlFormatter.xtend
+++ b/aml/org.testeditor.aml.dsl/src/org/testeditor/aml/dsl/formatting2/AmlFormatter.xtend
@@ -58,7 +58,7 @@ class AmlFormatter extends XbaseFormatter {
 	
 	private def void formatBrackets(EObject element, extension IFormattableDocument document) {
 		element.regionFor.keyword("{").prepend[oneSpace].append[setNewLines(1, 2, 2)]
-		element.interior[indent] 
+		element.regionFor.keywordPairs("{", "}").forEach[interior[indent]]
 		element.regionFor.keyword("}").prepend[setNewLines(1, 2, 2)]
 	}
 	

--- a/aml/org.testeditor.aml.dsl/src/org/testeditor/aml/dsl/formatting2/AmlFormatter.xtend
+++ b/aml/org.testeditor.aml.dsl/src/org/testeditor/aml/dsl/formatting2/AmlFormatter.xtend
@@ -31,7 +31,7 @@ class AmlFormatter extends XbaseFormatter {
 	
 	def dispatch void format(AmlModel model, extension IFormattableDocument document) {
 		model.eContents.forEach[
-			prepend[setNewLines(2, 2, 3)] // at least one empty line between elements
+			prepend[setNewLines(2, 2, 2)] // at least one empty line between elements
 			formatBrackets(document)
 			formatKeywords(document)
 			format
@@ -57,9 +57,9 @@ class AmlFormatter extends XbaseFormatter {
 	}
 	
 	private def void formatBrackets(EObject element, extension IFormattableDocument document) {
-		element.regionFor.keyword("{").prepend[oneSpace].append[newLine]
+		element.regionFor.keyword("{").prepend[oneSpace].append[setNewLines(1, 2, 2)]
 		element.interior[indent] 
-		element.regionFor.keyword("}").prepend[newLine]
+		element.regionFor.keyword("}").prepend[setNewLines(1, 2, 2)]
 	}
 	
 	private def void formatKeywords(EObject element, extension IFormattableDocument document) {
@@ -67,7 +67,7 @@ class AmlFormatter extends XbaseFormatter {
 		element.regionFor.keyword("type").surround[oneSpace]
 		element.regionFor.keyword("is").surround[oneSpace]
 		element.regionFor.keyword("=").surround[oneSpace]
-		element.regionFor.keywords("label", "template").forEach[prepend[newLine]]
+		element.regionFor.keywords("label", "template").forEach[prepend[setNewLines(1, 2, 2)]]
 	}
 	
 }


### PR DESCRIPTION
This fixes the formatting for the import section and components.