### PR TITLE
Set version to 1.2.0-SNAPSHOT

### DIFF
--- a/aml/org.testeditor.aml.dsl.ide/META-INF/MANIFEST.MF
+++ b/aml/org.testeditor.aml.dsl.ide/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.testeditor.aml.dsl.ide
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.testeditor.aml.dsl.ide.contentassist.antlr.internal,
  org.testeditor.aml.dsl.ide.contentassist.antlr

--- a/aml/org.testeditor.aml.dsl.ide/pom.xml
+++ b/aml/org.testeditor.aml.dsl.ide/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/aml/org.testeditor.aml.dsl.tests/META-INF/MANIFEST.MF
+++ b/aml/org.testeditor.aml.dsl.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.aml.dsl.tests
 Bundle-Vendor: Signal Iduna Corporation
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-SymbolicName: org.testeditor.aml.dsl.tests;singleton:=true
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/aml/org.testeditor.aml.dsl.tests/pom.xml
+++ b/aml/org.testeditor.aml.dsl.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/aml/org.testeditor.aml.dsl.ui.tests/META-INF/MANIFEST.MF
+++ b/aml/org.testeditor.aml.dsl.ui.tests/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.testeditor.aml.dsl.ui.tests
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.workbench;resolution:=optional,

--- a/aml/org.testeditor.aml.dsl.ui.tests/pom.xml
+++ b/aml/org.testeditor.aml.dsl.ui.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/aml/org.testeditor.aml.dsl.ui/META-INF/MANIFEST.MF
+++ b/aml/org.testeditor.aml.dsl.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.aml.dsl.ui
 Bundle-Vendor: Signal Iduna Corporation
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-SymbolicName: org.testeditor.aml.dsl.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.testeditor.aml.dsl,

--- a/aml/org.testeditor.aml.dsl.ui/pom.xml
+++ b/aml/org.testeditor.aml.dsl.ui/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/aml/org.testeditor.aml.dsl/META-INF/MANIFEST.MF
+++ b/aml/org.testeditor.aml.dsl/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.aml.dsl
 Bundle-Vendor: Signal Iduna Corporation
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-SymbolicName: org.testeditor.aml.dsl; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/aml/org.testeditor.aml.dsl/pom.xml
+++ b/aml/org.testeditor.aml.dsl/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent.dsl</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent.dsl</relativePath>
 	</parent>
 

--- a/aml/org.testeditor.aml.model/META-INF/MANIFEST.MF
+++ b/aml/org.testeditor.aml.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.testeditor.aml.model;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/aml/org.testeditor.aml.model/pom.xml
+++ b/aml/org.testeditor.aml.model/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/aml/org.testeditor.aml.sdk/feature.xml
+++ b/aml/org.testeditor.aml.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.testeditor.aml.sdk"
       label="AML SDK Feature"
-      version="1.1.0.qualifier">
+      version="1.2.0.qualifier">
 
    <copyright>
       Copyright (c) 2012 - 2015 Signal Iduna Corporation and others.

--- a/aml/org.testeditor.aml.sdk/pom.xml
+++ b/aml/org.testeditor.aml.sdk/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/aml/pom.xml
+++ b/aml/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent.dsl</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../releng/org.testeditor.releng.parent.dsl</relativePath>
 	</parent>
 

--- a/common/org.testeditor.dsl.common.testing/META-INF/MANIFEST.MF
+++ b/common/org.testeditor.dsl.common.testing/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.testeditor.dsl.common.testing
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.testeditor.dsl.common,
  org.eclipse.core.runtime,

--- a/common/org.testeditor.dsl.common.testing/pom.xml
+++ b/common/org.testeditor.dsl.common.testing/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent.dsl</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent.dsl</relativePath>
 	</parent>
 

--- a/common/org.testeditor.dsl.common.tests/META-INF/MANIFEST.MF
+++ b/common/org.testeditor.dsl.common.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests
 Bundle-SymbolicName: org.testeditor.dsl.common.tests
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Vendor: Signal Iduna Corporation
 Fragment-Host: org.testeditor.dsl.common;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/common/org.testeditor.dsl.common.tests/pom.xml
+++ b/common/org.testeditor.dsl.common.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent.dsl</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent.dsl</relativePath>
 	</parent>
 

--- a/common/org.testeditor.dsl.common.ui.tests/META-INF/MANIFEST.MF
+++ b/common/org.testeditor.dsl.common.ui.tests/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.testeditor.dsl.common.ui.tests
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Signal Iduna Corporation
 Require-Bundle: org.eclipse.xtend.lib.macro,

--- a/common/org.testeditor.dsl.common.ui.tests/pom.xml
+++ b/common/org.testeditor.dsl.common.ui.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent.dsl</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent.dsl</relativePath>
 	</parent>
 

--- a/common/org.testeditor.dsl.common.ui/META-INF/MANIFEST.MF
+++ b/common/org.testeditor.dsl.common.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Ui
 Bundle-SymbolicName: org.testeditor.dsl.common.ui;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Vendor: Signal Iduna Corporation
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.xtend.lib,

--- a/common/org.testeditor.dsl.common.ui/pom.xml
+++ b/common/org.testeditor.dsl.common.ui/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent.dsl</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent.dsl</relativePath>
 	</parent>
 

--- a/common/org.testeditor.dsl.common/META-INF/MANIFEST.MF
+++ b/common/org.testeditor.dsl.common/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.testeditor.dsl.common
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.xtend.lib.macro,
  org.eclipse.xtext,

--- a/common/org.testeditor.dsl.common/pom.xml
+++ b/common/org.testeditor.dsl.common/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent.dsl</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent.dsl</relativePath>
 	</parent>
 

--- a/common/org.testeditor.logging/META-INF/MANIFEST.MF
+++ b/common/org.testeditor.logging/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Logging
 Bundle-SymbolicName: org.testeditor.logging
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Require-Bundle: org.eclipse.core.runtime
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .,

--- a/common/org.testeditor.logging/pom.xml
+++ b/common/org.testeditor.logging/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent.dsl</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent.dsl</relativePath>
 	</parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent.dsl</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../releng/org.testeditor.releng.parent.dsl</relativePath>
 	</parent>
 

--- a/legacy/org.testeditor.aml.legacy.feature/feature.xml
+++ b/legacy/org.testeditor.aml.legacy.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.testeditor.aml.legacy.feature"
       label="AML Legacy Feature"
-      version="1.1.0.qualifier">
+      version="1.2.0.qualifier">
 
    <copyright>
       Copyright (c) 2012 - 2015 Signal Iduna Corporation and others.

--- a/legacy/org.testeditor.aml.legacy.feature/pom.xml
+++ b/legacy/org.testeditor.aml.legacy.feature/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/legacy/org.testeditor.aml.legacy.importer.ui/META-INF/MANIFEST.MF
+++ b/legacy/org.testeditor.aml.legacy.importer.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.aml.dsl.legacy
 Bundle-SymbolicName: org.testeditor.aml.legacy.importer.ui;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Activator: org.testeditor.aml.legacy.importer.ui.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/legacy/org.testeditor.aml.legacy.importer.ui/pom.xml
+++ b/legacy/org.testeditor.aml.legacy.importer.ui/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/legacy/org.testeditor.aml.legacy.model/META-INF/MANIFEST.MF
+++ b/legacy/org.testeditor.aml.legacy.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.aml.dsl.legacy.model
 Bundle-SymbolicName: org.testeditor.aml.legacy.model
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Vendor: Signal Iduna Corporation
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.xtend.lib,

--- a/legacy/org.testeditor.aml.legacy.model/pom.xml
+++ b/legacy/org.testeditor.aml.legacy.model/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent.dsl</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../releng/org.testeditor.releng.parent.dsl</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent.dsl</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>releng/org.testeditor.releng.parent.dsl</relativePath>
 	</parent>
 

--- a/rcp/org.testeditor.rcp4.feature/feature.xml
+++ b/rcp/org.testeditor.rcp4.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.testeditor.rcp4.feature"
       label="Feature"
-      version="1.1.0.qualifier">
+      version="1.2.0.qualifier">
 
    <description url="http://www.example.com/description">
       [Enter Feature Description here.]

--- a/rcp/org.testeditor.rcp4.feature/pom.xml
+++ b/rcp/org.testeditor.rcp4.feature/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/rcp/org.testeditor.rcp4.platform.feature/feature.xml
+++ b/rcp/org.testeditor.rcp4.platform.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.testeditor.rcp4.platform.feature"
       label="Platform Feature"
-      version="1.1.0.qualifier">
+      version="1.2.0.qualifier">
 
    <copyright>
       Copyright (c) 2012 - 2016 Signal Iduna Corporation and others.

--- a/rcp/org.testeditor.rcp4.platform.feature/pom.xml
+++ b/rcp/org.testeditor.rcp4.platform.feature/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/rcp/org.testeditor.rcp4.product/pom.xml
+++ b/rcp/org.testeditor.rcp4.product/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/rcp/org.testeditor.rcp4.product/testeditor.product
+++ b/rcp/org.testeditor.rcp4.product/testeditor.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="TestEditor" uid="testeditor_rcp" id="org.testeditor.rcp4.testeditor_rcp" application="org.testeditor.rcp4.application" version="1.1.0.qualifier" useFeatures="false" includeLaunchers="true">
+<product name="TestEditor" uid="testeditor_rcp" id="org.testeditor.rcp4.testeditor_rcp" application="org.testeditor.rcp4.application" version="1.2.0.qualifier" useFeatures="false" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -337,12 +337,12 @@
    </plugins>
 
    <features>
-      <feature id="org.testeditor.aml.legacy.feature" version="1.1.0.qualifier"/>
-      <feature id="org.testeditor.aml.sdk" version="1.1.0.qualifier"/>
-      <feature id="org.testeditor.tcl.sdk" version="1.1.0.qualifier"/>
-      <feature id="org.testeditor.tsl.sdk" version="1.1.0.qualifier"/>
-      <feature id="org.testeditor.rcp4.platform.feature" version="1.1.0.qualifier"/>
-      <feature id="org.testeditor.rcp4.feature" version="1.1.0.qualifier"/>
+      <feature id="org.testeditor.aml.legacy.feature" version="1.2.0.qualifier"/>
+      <feature id="org.testeditor.aml.sdk" version="1.2.0.qualifier"/>
+      <feature id="org.testeditor.tcl.sdk" version="1.2.0.qualifier"/>
+      <feature id="org.testeditor.tsl.sdk" version="1.2.0.qualifier"/>
+      <feature id="org.testeditor.rcp4.platform.feature" version="1.2.0.qualifier"/>
+      <feature id="org.testeditor.rcp4.feature" version="1.2.0.qualifier"/>
    </features>
 
    <configurations>

--- a/rcp/org.testeditor.rcp4.tcltestrun/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.tcltestrun/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tcltestrun
 Bundle-SymbolicName: org.testeditor.rcp4.tcltestrun;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Vendor: Signal Iduna Corporation
 Require-Bundle: org.eclipse.xtend.lib,
  org.eclipse.xtext.ui,

--- a/rcp/org.testeditor.rcp4.tcltestrun/pom.xml
+++ b/rcp/org.testeditor.rcp4.tcltestrun/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/rcp/org.testeditor.rcp4.tests/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Integration Tests of the rcp4
 Bundle-SymbolicName: org.testeditor.rcp4.tests
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Fragment-Host: org.testeditor.rcp4;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.testeditor.dsl.common.testing;bundle-version="1.0.0",

--- a/rcp/org.testeditor.rcp4.tests/pom.xml
+++ b/rcp/org.testeditor.rcp4.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/rcp/org.testeditor.rcp4.uatests/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.uatests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: User Acceptance Tests
 Bundle-SymbolicName: org.testeditor.rcp4.uatests
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.swtbot.eclipse.finder;bundle-version="2.3.0",
  org.junit;bundle-version="4.12.0",

--- a/rcp/org.testeditor.rcp4.uatests/pom.xml
+++ b/rcp/org.testeditor.rcp4.uatests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/rcp/org.testeditor.rcp4.updatesite/pom.xml
+++ b/rcp/org.testeditor.rcp4.updatesite/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/rcp/org.testeditor.rcp4.updatesite/site.xml
+++ b/rcp/org.testeditor.rcp4.updatesite/site.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/org.testeditor.tcl.sdk_1.1.0.qualifier.jar" id="org.testeditor.tcl.sdk" version="1.1.0.qualifier">
+   <feature url="features/org.testeditor.tcl.sdk_1.2.0.qualifier.jar" id="org.testeditor.tcl.sdk" version="1.2.0.qualifier">
       <category name="Testeditor"/>
    </feature>
-   <feature url="features/org.testeditor.aml.sdk_1.1.0.qualifier.jar" id="org.testeditor.aml.sdk" version="1.1.0.qualifier">
+   <feature url="features/org.testeditor.aml.sdk_1.2.0.qualifier.jar" id="org.testeditor.aml.sdk" version="1.2.0.qualifier">
       <category name="Testeditor"/>
    </feature>
-   <feature url="features/org.testeditor.tsl.sdk_1.1.0.qualifier.jar" id="org.testeditor.tsl.sdk" version="1.1.0.qualifier">
+   <feature url="features/org.testeditor.tsl.sdk_1.2.0.qualifier.jar" id="org.testeditor.tsl.sdk" version="1.2.0.qualifier">
       <category name="Testeditor"/>
    </feature>
-   <feature url="features/org.testeditor.rcp4.platform.feature_1.1.0.qualifier.jar" id="org.testeditor.rcp4.platform.feature" version="1.1.0.qualifier">
+   <feature url="features/org.testeditor.rcp4.platform.feature_1.2.0.qualifier.jar" id="org.testeditor.rcp4.platform.feature" version="1.2.0.qualifier">
       <category name="platform"/>
    </feature>
    <category-def name="Testeditor" label="Testeditor"/>

--- a/rcp/org.testeditor.rcp4.views.projectexplorer/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.views.projectexplorer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Projectexplorer
 Bundle-SymbolicName: org.testeditor.rcp4.views.projectexplorer;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Vendor: Signal Iduna Corporation
 Require-Bundle: org.eclipse.ui.navigator;bundle-version="3.6.0",
  org.eclipse.core.resources;bundle-version="3.10.1",

--- a/rcp/org.testeditor.rcp4.views.projectexplorer/pom.xml
+++ b/rcp/org.testeditor.rcp4.views.projectexplorer/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/rcp/org.testeditor.rcp4.views.tcltestrun/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.views.tcltestrun/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: TcltestrunUi
 Bundle-SymbolicName: org.testeditor.rcp4.views.tcltestrun;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.testeditor.tcl.dsl.ui,
  org.testeditor.rcp4.tcltestrun,

--- a/rcp/org.testeditor.rcp4.views.tcltestrun/pom.xml
+++ b/rcp/org.testeditor.rcp4.views.tcltestrun/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/rcp/org.testeditor.rcp4.views.teststepselection.tests/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.views.teststepselection.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.rcp4.views.teststepselector.tests
 Bundle-SymbolicName: org.testeditor.rcp4.views.teststepselector.tests;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Vendor: Signal Iduna Corporation
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/rcp/org.testeditor.rcp4.views.teststepselection.tests/pom.xml
+++ b/rcp/org.testeditor.rcp4.views.teststepselection.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/rcp/org.testeditor.rcp4.views.teststepselection/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.views.teststepselection/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.rcp4.views.teststepselector
 Bundle-SymbolicName: org.testeditor.rcp4.views.teststepselector;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Vendor: Signal Iduna Corporation
 Export-Package: org.testeditor.rcp4.views.teststepselector;
   uses:="org.eclipse.emf.ecore,

--- a/rcp/org.testeditor.rcp4.views.teststepselection/pom.xml
+++ b/rcp/org.testeditor.rcp4.views.teststepselection/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/rcp/org.testeditor.rcp4.views.testview/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.views.testview/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Testview
 Bundle-SymbolicName: org.testeditor.rcp4.views.testview;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Vendor: Signal Iduna Corporation
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/rcp/org.testeditor.rcp4.views.testview/pom.xml
+++ b/rcp/org.testeditor.rcp4.views.testview/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/rcp/org.testeditor.rcp4/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Product
 Bundle-SymbolicName: org.testeditor.rcp4;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,
  org.eclipse.ui.navigator,

--- a/rcp/org.testeditor.rcp4/pom.xml
+++ b/rcp/org.testeditor.rcp4/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/rcp/pom.xml
+++ b/rcp/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent.dsl</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../releng/org.testeditor.releng.parent.dsl</relativePath>
 	</parent>
 

--- a/releng/org.testeditor.releng.parent.dsl/pom.xml
+++ b/releng/org.testeditor.releng.parent.dsl/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/releng/org.testeditor.releng.parent/pom.xml
+++ b/releng/org.testeditor.releng.parent/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.testeditor</groupId>
 	<artifactId>org.testeditor.releng.parent</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>1.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/releng/org.testeditor.releng.target.parent/pom.xml
+++ b/releng/org.testeditor.releng.target.parent/pom.xml
@@ -5,7 +5,7 @@
 	
 	<groupId>org.testeditor</groupId>
 	<artifactId>org.testeditor.releng.target.parent</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>1.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/releng/org.testeditor.releng.target.thirdparty/feature.xml
+++ b/releng/org.testeditor.releng.target.thirdparty/feature.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="org.testeditor.releng.target.thirdparty"
-      version="1.1.0.qualifier">
+      version="1.2.0.qualifier">
 
    <copyright>
       Copyright (c) 2012 - 2015 Signal Iduna Corporation and others.

--- a/releng/org.testeditor.releng.target.thirdparty/pom.xml
+++ b/releng/org.testeditor.releng.target.thirdparty/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.target.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../org.testeditor.releng.target.parent</relativePath>
 	</parent>
 

--- a/releng/org.testeditor.releng.target.updatesite/pom.xml
+++ b/releng/org.testeditor.releng.target.updatesite/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.target.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../org.testeditor.releng.target.parent</relativePath>
 	</parent>
 

--- a/releng/org.testeditor.releng.target.updatesite/site.xml
+++ b/releng/org.testeditor.releng.target.updatesite/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/org.testeditor.releng.target.thirdparty_1.1.0.qualifier.qualifier.jar" id="org.testeditor.releng.target.thirdparty" version="1.1.0.qualifier"/>
+   <feature url="features/org.testeditor.releng.target.thirdparty_1.2.0.qualifier.qualifier.jar" id="org.testeditor.releng.target.thirdparty" version="1.2.0.qualifier"/>
    <feature url="features/org.eclipse.emf.sdk_2.11.1.v20150806-0404.jar" id="org.eclipse.emf.sdk" version="2.11.1.v20150806-0404"/>
    <feature url="features/org.eclipse.emf.ecore.xcore.sdk_1.3.1.v20150806-0546.jar" id="org.eclipse.emf.ecore.xcore.sdk" version="1.3.1.v20150806-0546"/>
    <feature url="features/org.eclipse.emf.mwe2.language.sdk_2.8.1.v201508030411.jar" id="org.eclipse.emf.mwe2.language.sdk" version="2.8.1.v201508030411"/>

--- a/releng/org.testeditor.releng.target/pom.xml
+++ b/releng/org.testeditor.releng.target/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.target.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../org.testeditor.releng.target.parent</relativePath>
 	</parent>
 

--- a/tcl/org.testeditor.tcl.dsl.ide/META-INF/MANIFEST.MF
+++ b/tcl/org.testeditor.tcl.dsl.ide/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.testeditor.tcl.dsl.ide
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.testeditor.tcl.dsl.ide.contentassist.antlr,
  org.testeditor.tcl.dsl.ide.contentassist.antlr.internal,

--- a/tcl/org.testeditor.tcl.dsl.ide/pom.xml
+++ b/tcl/org.testeditor.tcl.dsl.ide/pom.xml
@@ -6,7 +6,7 @@
 		<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/tcl/org.testeditor.tcl.dsl.tests/META-INF/MANIFEST.MF
+++ b/tcl/org.testeditor.tcl.dsl.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.tcl.dsl.tests
 Bundle-Vendor: Signal Iduna Corporation
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-SymbolicName: org.testeditor.tcl.dsl.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tcl/org.testeditor.tcl.dsl.tests/pom.xml
+++ b/tcl/org.testeditor.tcl.dsl.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/tcl/org.testeditor.tcl.dsl.ui.tests/META-INF/MANIFEST.MF
+++ b/tcl/org.testeditor.tcl.dsl.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.tcl.dsl.ui.tests
 Bundle-SymbolicName: org.testeditor.tcl.dsl.ui.tests
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Fragment-Host: org.testeditor.tcl.dsl.ui
 Require-Bundle: org.junit,

--- a/tcl/org.testeditor.tcl.dsl.ui.tests/pom.xml
+++ b/tcl/org.testeditor.tcl.dsl.ui.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/tcl/org.testeditor.tcl.dsl.ui/META-INF/MANIFEST.MF
+++ b/tcl/org.testeditor.tcl.dsl.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.tcl.dsl.ui
 Bundle-Vendor: Signal Iduna Corporation
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-SymbolicName: org.testeditor.tcl.dsl.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tcl/org.testeditor.tcl.dsl.ui/pom.xml
+++ b/tcl/org.testeditor.tcl.dsl.ui/pom.xml
@@ -6,7 +6,7 @@
 		<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/tcl/org.testeditor.tcl.dsl/META-INF/MANIFEST.MF
+++ b/tcl/org.testeditor.tcl.dsl/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.tcl.dsl
 Bundle-Vendor: Signal Iduna Corporation
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-SymbolicName: org.testeditor.tcl.dsl; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/tcl/org.testeditor.tcl.dsl/pom.xml
+++ b/tcl/org.testeditor.tcl.dsl/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent.dsl</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent.dsl</relativePath>
 	</parent>
 

--- a/tcl/org.testeditor.tcl.model/META-INF/MANIFEST.MF
+++ b/tcl/org.testeditor.tcl.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.tcl.model
 Bundle-SymbolicName: org.testeditor.tcl.model;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Signal Iduna Corporation
 Bundle-Localization: plugin

--- a/tcl/org.testeditor.tcl.model/pom.xml
+++ b/tcl/org.testeditor.tcl.model/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/tcl/org.testeditor.tcl.sdk/feature.xml
+++ b/tcl/org.testeditor.tcl.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.testeditor.tcl.sdk"
       label="Tcl SDK Feature "
-      version="1.1.0.qualifier">
+      version="1.2.0.qualifier">
 
    <copyright>
       Copyright (c) 2012 - 2015 Signal Iduna Corporation and others.

--- a/tcl/org.testeditor.tcl.sdk/pom.xml
+++ b/tcl/org.testeditor.tcl.sdk/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/tcl/pom.xml
+++ b/tcl/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent.dsl</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../releng/org.testeditor.releng.parent.dsl</relativePath>
 	</parent>
 

--- a/tml/org.testeditor.tml.dsl.ide/META-INF/MANIFEST.MF
+++ b/tml/org.testeditor.tml.dsl.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.tml.dsl.ide
 Bundle-Vendor: Signal Iduna Corporation
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-SymbolicName: org.testeditor.tml.dsl.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.testeditor.tml.dsl,

--- a/tml/org.testeditor.tml.dsl.ide/pom.xml
+++ b/tml/org.testeditor.tml.dsl.ide/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/tml/org.testeditor.tml.dsl.tests/META-INF/MANIFEST.MF
+++ b/tml/org.testeditor.tml.dsl.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.tml.dsl.tests
 Bundle-Vendor: Signal Iduna Corporation
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-SymbolicName: org.testeditor.tml.dsl.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.testeditor.tml.dsl,

--- a/tml/org.testeditor.tml.dsl.tests/pom.xml
+++ b/tml/org.testeditor.tml.dsl.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/tml/org.testeditor.tml.dsl.ui.tests/META-INF/MANIFEST.MF
+++ b/tml/org.testeditor.tml.dsl.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.tml.dsl.ui.tests
 Bundle-Vendor: Signal Iduna Corporation
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-SymbolicName: org.testeditor.tml.dsl.ui.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.testeditor.tml.dsl.ui,

--- a/tml/org.testeditor.tml.dsl.ui.tests/pom.xml
+++ b/tml/org.testeditor.tml.dsl.ui.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/tml/org.testeditor.tml.dsl.ui/META-INF/MANIFEST.MF
+++ b/tml/org.testeditor.tml.dsl.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.tml.dsl.ui
 Bundle-Vendor: Signal Iduna Corporation
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-SymbolicName: org.testeditor.tml.dsl.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.testeditor.tml.dsl,

--- a/tml/org.testeditor.tml.dsl.ui/pom.xml
+++ b/tml/org.testeditor.tml.dsl.ui/pom.xml
@@ -6,7 +6,7 @@
 		<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/tml/org.testeditor.tml.dsl/META-INF/MANIFEST.MF
+++ b/tml/org.testeditor.tml.dsl/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.tml.dsl
 Bundle-Vendor: Signal Iduna Corporation
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-SymbolicName: org.testeditor.tml.dsl; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/tml/org.testeditor.tml.dsl/pom.xml
+++ b/tml/org.testeditor.tml.dsl/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent.dsl</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent.dsl</relativePath>
 	</parent>
 

--- a/tml/org.testeditor.tml.model/META-INF/MANIFEST.MF
+++ b/tml/org.testeditor.tml.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.tml.model
 Bundle-SymbolicName: org.testeditor.tml.model;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Signal Iduna Corporation
 Bundle-Localization: plugin

--- a/tml/org.testeditor.tml.model/pom.xml
+++ b/tml/org.testeditor.tml.model/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/tml/org.testeditor.tml.sdk/feature.xml
+++ b/tml/org.testeditor.tml.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.testeditor.tml.sdk"
       label="Tml SDK Feature"
-      version="1.1.0.qualifier">
+      version="1.2.0.qualifier">
 
    <description url="http://www.example.com/description">
       [Enter Feature Description here.]

--- a/tml/org.testeditor.tml.sdk/pom.xml
+++ b/tml/org.testeditor.tml.sdk/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/tml/pom.xml
+++ b/tml/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent.dsl</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../releng/org.testeditor.releng.parent.dsl</relativePath>
 	</parent>
 

--- a/tsl/org.testeditor.tsl.dsl.ide/META-INF/MANIFEST.MF
+++ b/tsl/org.testeditor.tsl.dsl.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.tsl.dsl.ide
 Bundle-Vendor: Signal Iduna Corporation
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-SymbolicName: org.testeditor.tsl.dsl.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.testeditor.tsl.dsl,

--- a/tsl/org.testeditor.tsl.dsl.ide/pom.xml
+++ b/tsl/org.testeditor.tsl.dsl.ide/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 	<artifactId>org.testeditor.tsl.dsl.ide</artifactId>

--- a/tsl/org.testeditor.tsl.dsl.tests/META-INF/MANIFEST.MF
+++ b/tsl/org.testeditor.tsl.dsl.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.tsl.dsl.tests
 Bundle-Vendor: Signal Iduna Corporation
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-SymbolicName: org.testeditor.tsl.dsl.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tsl/org.testeditor.tsl.dsl.tests/pom.xml
+++ b/tsl/org.testeditor.tsl.dsl.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/tsl/org.testeditor.tsl.dsl.ui/META-INF/MANIFEST.MF
+++ b/tsl/org.testeditor.tsl.dsl.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.tsl.dsl.ui
 Bundle-Vendor: Signal Iduna Corporation
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-SymbolicName: org.testeditor.tsl.dsl.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tsl/org.testeditor.tsl.dsl.ui/pom.xml
+++ b/tsl/org.testeditor.tsl.dsl.ui/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/tsl/org.testeditor.tsl.dsl.web/pom.xml
+++ b/tsl/org.testeditor.tsl.dsl.web/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/tsl/org.testeditor.tsl.dsl/META-INF/MANIFEST.MF
+++ b/tsl/org.testeditor.tsl.dsl/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-SymbolicName: org.testeditor.tsl.dsl; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.testeditor.tsl.model;visibility:=reexport,

--- a/tsl/org.testeditor.tsl.dsl/pom.xml
+++ b/tsl/org.testeditor.tsl.dsl/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent.dsl</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent.dsl</relativePath>
 	</parent>
 

--- a/tsl/org.testeditor.tsl.model/META-INF/MANIFEST.MF
+++ b/tsl/org.testeditor.tsl.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.testeditor.tsl.model
 Bundle-SymbolicName: org.testeditor.tsl.model;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Signal Iduna Corporation
 Bundle-Localization: plugin

--- a/tsl/org.testeditor.tsl.model/pom.xml
+++ b/tsl/org.testeditor.tsl.model/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/tsl/org.testeditor.tsl.sdk/feature.xml
+++ b/tsl/org.testeditor.tsl.sdk/feature.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="org.testeditor.tsl.sdk"
-      version="1.1.0.qualifier">
+      version="1.2.0.qualifier">
 
    <plugin
          id="org.testeditor.tsl.dsl"

--- a/tsl/org.testeditor.tsl.sdk/pom.xml
+++ b/tsl/org.testeditor.tsl.sdk/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 

--- a/tsl/pom.xml
+++ b/tsl/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.testeditor</groupId>
 		<artifactId>org.testeditor.releng.parent.dsl</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../releng/org.testeditor.releng.parent.dsl</relativePath>
 	</parent>
 


### PR DESCRIPTION
Bumping the version number failed in the release process so we need to do it manually once.
Release process should be fixed and work properly for future releases.