### PR TITLE
Allow building the product on feature branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,8 +50,8 @@ nodeWithProperWorkspace {
         }
     }
     
-    // workaround for now to speed-up the build: only build the product on develop and master
-    def buildProduct = env.BRANCH_NAME == 'develop' || isMaster()
+    // workaround for now to speed-up the build: only build the product on develop, master and branches that end with -with-product
+    def buildProduct = env.BRANCH_NAME ==~ "develop|.*-with-product" || isMaster()
     if (buildProduct) {
         stage 'Build product'
         withMavenEnv(["MAVEN_OPTS=-Xms512m -Xmx2g"]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ nodeWithProperWorkspace {
     }
     
     // workaround for now to speed-up the build: only build the product on develop, master and branches that end with -with-product
-    def buildProduct = env.BRANCH_NAME ==~ "develop|.*-with-product" || isMaster()
+    def buildProduct = env.BRANCH_NAME == "develop" || env.BRANCH_NAME.endsWith("-with-product") || isMaster()
     if (buildProduct) {
         stage 'Build product'
         withMavenEnv(["MAVEN_OPTS=-Xms512m -Xmx2g"]) {


### PR DESCRIPTION
Sometimes we want to build the product on feature branches as well (for example when we change the project structure).

With this change we can add `-with-product` to a branch name if we want the product to be built on this branch.