### PR TITLE
remove unused dependency, ignore emf-generated txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ tmp/
 local.properties
 Eclipse.app
 .recommenders
+aml/org.testeditor.aml.model/text/
+tcl/org.testeditor.tcl.model/text/
+tsl/org.testeditor.tsl.model/text/

--- a/common/org.testeditor.dsl.common.testing/META-INF/MANIFEST.MF
+++ b/common/org.testeditor.dsl.common.testing/META-INF/MANIFEST.MF
@@ -3,8 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.testeditor.dsl.common.testing
 Bundle-Version: 1.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.testeditor.dsl.common,
- org.eclipse.core.runtime,
+Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtext,
  org.junit;bundle-version="4.12.0"

--- a/tcl/org.testeditor.tcl.dsl/META-INF/MANIFEST.MF
+++ b/tcl/org.testeditor.tcl.dsl/META-INF/MANIFEST.MF
@@ -18,8 +18,7 @@ Require-Bundle: org.eclipse.xtext,
  org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional,
  org.eclipse.xtext.util,
  org.eclipse.xtend.lib,
- org.testeditor.aml.dsl,
- org.testeditor.tsl.dsl
+ org.testeditor.aml.dsl
 Import-Package: org.apache.log4j,
  javax.inject,
  org.apache.commons.lang3


### PR DESCRIPTION
After upgrading to new eclipse neon, some workspace issues popped up 
* exporting plugins failed because of circular dependencies
* text files were generated by emf-plugin