### PR TITLE
TE-402 support test setup and cleanup part 1

### DIFF
--- a/common/org.testeditor.dsl.common.testing/src/org/testeditor/dsl/common/testing/DummyFixture.xtend
+++ b/common/org.testeditor.dsl.common.testing/src/org/testeditor/dsl/common/testing/DummyFixture.xtend
@@ -30,6 +30,10 @@ public class DummyFixture {
 	}
 
 	@FixtureMethod
+	def void stopApplication() {
+	}
+
+	@FixtureMethod
 	def void waitSeconds(long secs) {
 	}
 

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/SimpleTclGeneratorIntegrationTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/SimpleTclGeneratorIntegrationTest.xtend
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
  * Contributors:
  * Signal Iduna Corporation - initial API and implementation
  * akquinet AG
@@ -19,53 +19,55 @@ import static extension org.eclipse.emf.common.util.URI.createFileURI
 
 class SimpleTclGeneratorIntegrationTest extends AbstractTclGeneratorIntegrationTest {
 
-	@Test
-	def void test() {
-		// given
-		val aml = '''
-			package com.example
-			
-			import «DummyFixture.name»
-			
-			component type Application {
-				interactions = start, stop
+	// TODO extract this to DummyFixture.getAmlModel()
+	val aml = '''
+		package com.example
+		
+		import «DummyFixture.name»
+		
+		component type Application {
+			interactions = start, stop
+		}
+		 
+		interaction type start {
+			template = "Starte Anwendung" ${path}
+			method = «DummyFixture.simpleName».startApplication(path)
+		}
+		interaction type stop {
+			template = "Stoppe Anwendung"
+			method = «DummyFixture.simpleName».stopApplication
+		}
+		 
+		interaction type getValue {
+			template = "Lese Wert von" ${element}
+			method = «DummyFixture.simpleName».getValue(element)
+		}
+		 
+		interaction type setValue {
+			template = "Setze Wert von" ${element} "auf" ${value} "."
+			method = «DummyFixture.simpleName».setValue(element, value)
+		}
+		
+		interaction type getList {
+			template = "Lese Liste von" ${element}
+			method = «DummyFixture.simpleName».getList(element)
+		}
+		
+		element type Label{
+			interactions = getList
+		}
+					
+		component GreetingApplication is Application {
+			element bar is Label {
+				label = "Label"
+				locator = "label.greet"
 			}
-			 
-			interaction type start {
-				template = "Starte Anwendung" ${path}
-				method = «DummyFixture.simpleName».startApplication(path)
-			}
-			interaction type stop {
-				template = "Stoppe Anwendung"
-				method = «DummyFixture.simpleName».stopApplication
-			}
-			 
-			interaction type getValue {
-				template = "Lese Wert von" ${element}
-				method = «DummyFixture.simpleName».getValue(element)
-			}
-			 
-			interaction type setValue {
-				template = "Setze Wert von" ${element} "auf" ${value} "."
-				method = «DummyFixture.simpleName».setValue(element, value)
-			}
+		}
+	'''
 
-			interaction type getList {
-				template = "Lese Liste von" ${element}
-				method = «DummyFixture.simpleName».getList(element)
-			}
-			
-			element type Label{
-				interactions = getList
-			}
-						
-			component GreetingApplication is Application {
-				element bar is Label {
-					label = "Label"
-					locator = "label.greet"
-				}
-			}
-		'''
+	@Test
+	def void testDefaultGeneration() {
+		// given
 		val tcl = '''
 			package com.example
 			
@@ -84,10 +86,116 @@ class SimpleTclGeneratorIntegrationTest extends AbstractTclGeneratorIntegrationT
 		tclModel.assertNoSyntaxErrors
 
 		// when
-		val obj = generate(tclModel)
+		val generatedCode = generate(tclModel)
 
 		// then
-		println(obj)
+		generatedCode.assertEquals('''
+			package com.example;
+			
+			import org.junit.Test;
+			import org.testeditor.dsl.common.testing.DummyFixture;
+			
+			/**
+			 * Generated from SimpleTest.tcl
+			 */
+			@SuppressWarnings("all")
+			public class SimpleTest {
+			  private DummyFixture dummyFixture = new DummyFixture();
+			  
+			  @Test
+			  public void execute() throws Exception {
+			    
+			    /* Start the famous greetings application */
+			    
+			    // Component: GreetingApplication
+			    
+			    // - Starte Anwendung "org.testeditor.swing.exammple.Greetings"
+			    dummyFixture.startApplication("org.testeditor.swing.exammple.Greetings");
+			    // - Lese Liste von <bar>
+			    java.util.List<? extends java.lang.Object> foo = dummyFixture.getList("label.greet");
+			    // - Stoppe Anwendung
+			    dummyFixture.();
+			    /* Do something different */
+			    
+			  }
+			}
+		'''.toString.replaceAll('\r\n', '\n'))
+	}
+
+	@Test
+	def void testGenerationWithBeforeAndAfter() {
+		// given
+		val tcl = '''
+			package com.example
+			
+			# SimpleTest
+			
+			Setup:
+				Component: GreetingApplication
+				- Starte Anwendung "org.testeditor.swing.exammple.Greetings"
+			
+			Cleanup:
+				Component: GreetingApplication
+				- Starte Anwendung "org.testeditor.swing.exammple.Greetings"
+			
+			* Test Step
+				Mask: GreetingApplication
+				- foo = Lese Liste von <bar>
+		'''
+		val amlModel = amlParseHelper.parse(aml, resourceSet)
+		val tclModel = tclParseHelper.parse(tcl, 'SimpleTest.tcl'.createFileURI, resourceSet)
+		amlModel.assertNoSyntaxErrors
+		tclModel.assertNoSyntaxErrors
+		
+		// when
+		val generatedCode = tclModel.generate
+		
+		// then
+		generatedCode.assertEquals('''
+			package com.example;
+			
+			import org.junit.After;
+			import org.junit.Before;
+			import org.junit.Test;
+			import org.testeditor.dsl.common.testing.DummyFixture;
+			
+			/**
+			 * Generated from SimpleTest.tcl
+			 */
+			@SuppressWarnings("all")
+			public class SimpleTest {
+			  private DummyFixture dummyFixture = new DummyFixture();
+			  
+			  @Before
+			  public void setup() throws Exception {
+			    
+			    // Component: GreetingApplication
+			    
+			    // - Starte Anwendung "org.testeditor.swing.exammple.Greetings"
+			    dummyFixture.startApplication("org.testeditor.swing.exammple.Greetings");
+			  }
+			  
+			  @After
+			  public void cleanup() throws Exception {
+			    
+			    // Component: GreetingApplication
+			    
+			    // - Starte Anwendung "org.testeditor.swing.exammple.Greetings"
+			    dummyFixture.startApplication("org.testeditor.swing.exammple.Greetings");
+			  }
+			  
+			  @Test
+			  public void execute() throws Exception {
+			    
+			    /* Test Step */
+			    
+			    // Component: GreetingApplication
+			    
+			    // - Lese Liste von <bar>
+			    java.util.List<? extends java.lang.Object> foo = dummyFixture.getList("label.greet");
+			  }
+			}
+		'''.toString.replaceAll('\r\n', '\n'))
 	}
 
 }

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/SimpleTclGeneratorIntegrationTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/SimpleTclGeneratorIntegrationTest.xtend
@@ -35,7 +35,7 @@ class SimpleTclGeneratorIntegrationTest extends AbstractTclGeneratorIntegrationT
 		}
 		interaction type stop {
 			template = "Stoppe Anwendung"
-			method = «DummyFixture.simpleName».stopApplication
+			method = «DummyFixture.simpleName».stopApplication()
 		}
 		 
 		interaction type getValue {
@@ -53,7 +53,7 @@ class SimpleTclGeneratorIntegrationTest extends AbstractTclGeneratorIntegrationT
 			method = «DummyFixture.simpleName».getList(element)
 		}
 		
-		element type Label{
+		element type Label {
 			interactions = getList
 		}
 					
@@ -114,7 +114,7 @@ class SimpleTclGeneratorIntegrationTest extends AbstractTclGeneratorIntegrationT
 			    // - Lese Liste von <bar>
 			    java.util.List<? extends java.lang.Object> foo = dummyFixture.getList("label.greet");
 			    // - Stoppe Anwendung
-			    dummyFixture.();
+			    dummyFixture.stopApplication();
 			    /* Do something different */
 			    
 			  }
@@ -136,7 +136,7 @@ class SimpleTclGeneratorIntegrationTest extends AbstractTclGeneratorIntegrationT
 			
 			Cleanup:
 				Component: GreetingApplication
-				- Starte Anwendung "org.testeditor.swing.exammple.Greetings"
+				- Stoppe Anwendung
 			
 			* Test Step
 				Mask: GreetingApplication
@@ -180,8 +180,8 @@ class SimpleTclGeneratorIntegrationTest extends AbstractTclGeneratorIntegrationT
 			    
 			    // Component: GreetingApplication
 			    
-			    // - Starte Anwendung "org.testeditor.swing.exammple.Greetings"
-			    dummyFixture.startApplication("org.testeditor.swing.exammple.Greetings");
+			    // - Stoppe Anwendung
+			    dummyFixture.stopApplication();
 			  }
 			  
 			  @Test

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/formatter/TclModelFormatterTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/formatter/TclModelFormatterTest.xtend
@@ -97,10 +97,10 @@ class TclModelFormatterTest extends AbstractTclFormatterTest {
 				import c.d.e 
 				         require            freq          ,            breq            #
 				testCase   	implements      SomeSpec
-				'''
+			'''
 		]
 	}
-	
+
 	@Test
 	def void formatLineBreaksTml() {
 		assertFormatted [
@@ -140,5 +140,30 @@ class TclModelFormatterTest extends AbstractTclFormatterTest {
 				    #    MacroCollection
 			'''
 		]
-	}	
+	}
+
+	@Test
+	def void formatSetupAndCleanup() {
+		val keywords = #['Setup', 'Cleanup']
+		keywords.forEach [ keyword |
+			assertFormatted [
+				expectation = '''
+					package com.example
+					
+					# Test
+					
+					«keyword»:
+					
+						Component: myComponent
+						- sample setup
+				'''
+				toBeFormatted = '''
+					package com.example
+									
+					# Test    «keyword»   :  Component: myComponent - sample setup
+				'''
+			]
+		]
+	}
+
 }

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/parser/TclModelParserTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/parser/TclModelParserTest.xtend
@@ -236,7 +236,7 @@ class TclModelParserTest extends AbstractParserTest {
 	}
 
 	@Test
-	def void parseMacroTestStep(){
+	def void parseMacroTestStep() {
 		// given
 		val input = '''
 			package com.example
@@ -286,4 +286,101 @@ class TclModelParserTest extends AbstractParserTest {
 		// then
 		model.package.assertEquals('com.example')
 	}
+
+	@Test
+	def void parseSetup() {
+		// given
+		val input = '''
+			package com.example
+			
+			# Test
+			
+			Setup:
+				Component: Demo
+		'''
+
+		// when
+		val test = parse(input).test
+
+		// then
+		test.assertNoSyntaxErrors
+		test.setup.assertNotNull
+		test.setup.contexts.assertSingleElement
+	}
+
+	@Test
+	def void parseCleanup() {
+		// given
+		val input = '''
+			package com.example
+			
+			# Test
+			
+			Cleanup:
+				Component: Demo
+		'''
+
+		// when
+		val test = parse(input).test
+
+		// then
+		test.assertNoSyntaxErrors
+		test.cleanup.assertNotNull
+		test.cleanup.contexts.assertSingleElement
+	}
+
+	@Test
+	def void parseSetupAndCleanupBeforeSpecificationSteps() {
+		// given
+		val input = '''
+			package com.example
+			
+			# Test
+			
+			Setup:
+				Component: MySetupComponent
+			
+			Cleanup:
+				Component: MyCleanupComponent
+			
+			* step1
+		'''
+
+		// when
+		val test = parse(input).test
+
+		// then
+		test.assertNoSyntaxErrors
+		test.setup.assertNotNull
+		test.cleanup.assertNotNull
+		test.steps.assertSingleElement
+	}
+
+	@Test
+	def void parseSetupAndCleanupAfterSpecificationSteps() {
+		// given
+		val input = '''
+			package com.example
+			
+			# Test
+			
+			* step1
+			
+			Cleanup:
+				Component: MyCleanupComponent
+			
+			Setup:
+				Component: MySetupComponent
+		'''
+
+		// when
+		val test = parse(input).test
+
+		// then
+		test.assertNoSyntaxErrors
+		test.setup.assertNotNull
+		test.cleanup.assertNotNull
+		test.steps.assertSingleElement
+	}
+
 }

--- a/tcl/org.testeditor.tcl.dsl.ui.tests/src/org/testeditor/tcl/dsl/ui/tests/contentassist/TclTestCaseContentAssistTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.ui.tests/src/org/testeditor/tcl/dsl/ui/tests/contentassist/TclTestCaseContentAssistTest.xtend
@@ -15,7 +15,7 @@ class TclTestCaseContentAssistTest extends AbstractTclContentAssistTest {
 		''')
 
 		// expect
-		builder.assertTextAtCursorPosition("Mask", "* ", "implements")
+		builder.assertTextAtCursorPosition("Mask", "Cleanup", "Setup", "* ", "implements")
 	}
 
 	@Test
@@ -25,7 +25,7 @@ class TclTestCaseContentAssistTest extends AbstractTclContentAssistTest {
 			# Test implements Target
 			
 			Mask: SomeMask
-		''').assertTextAtCursorPosition("Mask", "* ")
+		''').assertTextAtCursorPosition("Mask", "Cleanup", "Setup", "* ")
 	}
 
 }

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/Tcl.xtext
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/Tcl.xtext
@@ -27,7 +27,23 @@ TclModel:
 TestCase:
 	'#' name=ID
 	('implements' specification=[tsl::TestSpecification|QualifiedName])?
-	steps+=SpecificationStepImplementation*;
+	( // allow user to define setup and cleanup either at the beginning or end
+		(setup=TestSetup)?
+	 &  (cleanup=TestCleanup)?
+	 &  steps+=SpecificationStepImplementation*
+	);
+
+TestSetup: 
+	{TestSetup}
+	'Setup' ':'
+	contexts+=TestStepContext*
+;
+
+TestCleanup: 
+	{TestCleanup}
+	'Cleanup' ':'
+	contexts+=TestStepContext*
+;
 
 SpecificationStepImplementation:
 	{SpecificationStepImplementation}

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/formatting2/TclFormatter.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/formatting2/TclFormatter.xtend
@@ -24,6 +24,8 @@ import org.testeditor.tcl.StepContentElement
 import org.testeditor.tcl.StepContentVariableReference
 import org.testeditor.tcl.TclModel
 import org.testeditor.tcl.TestCase
+import org.testeditor.tcl.TestCleanup
+import org.testeditor.tcl.TestSetup
 import org.testeditor.tcl.TestStep
 import org.testeditor.tsl.StepContentText
 import org.testeditor.tsl.StepContentVariable
@@ -49,7 +51,23 @@ class TclFormatter extends XbaseFormatter {
 		testCase.regionFor.keyword("implements").prepend[oneSpace]
 		testCase.regionFor.feature(TEST_CASE__SPECIFICATION).prepend[oneSpace]
 		// testCase.interior[indent] // configurable?
+		testCase.setup?.format
+		testCase.cleanup?.format
 		testCase.steps.forEach[format]
+	}
+
+	def dispatch void format(TestSetup element, extension IFormattableDocument document) {
+		element.regionFor.keyword("Setup").prepend[newLines = 2]
+		element.regionFor.keyword(":").prepend[noSpace]
+		element.interior[indent]
+		element.contexts.forEach[format]
+	}
+
+	def dispatch void format(TestCleanup element, extension IFormattableDocument document) {
+		element.regionFor.keyword("Cleanup").prepend[newLines = 2]
+		element.regionFor.keyword(":").prepend[noSpace]
+		element.interior[indent]
+		element.contexts.forEach[format]
 	}
 
 	def dispatch void format(SpecificationStepImplementation step, extension IFormattableDocument document) {

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
@@ -35,6 +35,8 @@ import org.testeditor.tcl.StepContentElement
 import org.testeditor.tcl.StepContentVariableReference
 import org.testeditor.tcl.TclModel
 import org.testeditor.tcl.TestCase
+import org.testeditor.tcl.TestCleanup
+import org.testeditor.tcl.TestSetup
 import org.testeditor.tcl.TestStep
 import org.testeditor.tcl.TestStepWithAssignment
 import org.testeditor.tcl.util.TclModelUtil
@@ -76,7 +78,7 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 					initializer = '''System.getenv("«environmentVariableReference.name»")'''
 				]
 			]
-			if (! envParams.empty) {
+			if (!envParams.empty) {
 				members += test.toMethod('checkEnvironmentVariablesOnExistence', typeRef(Void.TYPE)) [
 					exceptions += typeRef(Exception)
 					annotations += annotationRef('org.junit.Before') // make sure that junit is in the classpath of the workspace containing the dsl
@@ -86,11 +88,43 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 					]
 				]
 			}
+
+			// Create @Before method if relevant
+			if (test.setup !== null) {
+				members += test.setup.createSetupMethod(envParams)
+			}
+			// Create @After method if relevant
+			if (test.cleanup !== null) {
+				members += test.cleanup.createCleanupMethod(envParams)
+			}
+
 			// Create test method
 			members += test.toMethod('execute', typeRef(Void.TYPE)) [
 				exceptions += typeRef(Exception)
 				annotations += annotationRef('org.junit.Test') // make sure that junit is in the classpath of the workspace containing the dsl
 				body = [test.generateMethodBody(trace(test, true), envParams)]
+			]
+		]
+	}
+	
+	private def JvmOperation createSetupMethod(TestSetup setup, Iterable<EnvironmentVariableReference> envParams) {
+		return setup.toMethod('setup', typeRef(Void.TYPE)) [
+			exceptions += typeRef(Exception)
+			annotations += annotationRef('org.junit.Before')
+			body = [
+				val output = trace(setup, true)
+				setup.contexts.forEach[generateContext(output.trace(it), #[], envParams)]
+			]
+		]
+	}
+
+	private def JvmOperation createCleanupMethod(TestCleanup cleanup, Iterable<EnvironmentVariableReference> envParams) {
+		return cleanup.toMethod('cleanup', typeRef(Void.TYPE)) [
+			exceptions += typeRef(Exception)
+			annotations += annotationRef('org.junit.After')
+			body = [
+				val output = trace(cleanup, true)
+				cleanup.contexts.forEach[generateContext(output.trace(it), #[], envParams)]
 			]
 		]
 	}

--- a/tcl/org.testeditor.tcl.model/model/tcl.xcore
+++ b/tcl/org.testeditor.tcl.model/model/tcl.xcore
@@ -38,15 +38,32 @@ class TestCase {
 	String name
 	container derived TclModel model opposite test
 	refers TestSpecification specification
+	contains TestSetup setup
+	contains TestCleanup cleanup
 	contains SpecificationStepImplementation[0..*] steps opposite test
 }
 
-class SpecificationStepImplementation extends SpecificationStep {
+class SpecificationStepImplementation extends SpecificationStep, StepContainer {
 	container derived TestCase test opposite steps
-	contains TestStepContext[0..*] contexts
 }
 
 class EnvironmentVariableReference extends VariableReference {
+}
+
+/*
+ * Defines the steps that shall be executed before each test execution.
+ */
+class TestSetup extends StepContainer {
+}
+
+/*
+ * Defines the steps that shall be executed after each test execution.
+ */
+class TestCleanup extends StepContainer {
+}
+
+abstract class StepContainer {
+	contains TestStepContext[0..*] contexts
 }
 
 class MacroCollection {
@@ -55,10 +72,9 @@ class MacroCollection {
 	contains Macro[0..*] macros
 }
 
-class Macro {
+class Macro extends StepContainer {
 	String name
 	contains Template template
-	contains TestStepContext[0..*] contexts
 }
 
 abstract class TestStepContext {


### PR DESCRIPTION
Support a test setup and cleanup for the test-cases. This is part 1, reusing such definitions by multiple tests is not yet implemented.