### PR TITLE
TE-405 Improve existing tests by waiting for the "Progress Information" dialog to vanish

### DIFF
--- a/rcp/org.testeditor.rcp4.uatests/src/main/java/org/testeditor/fixture/swt/SWTFixture.java
+++ b/rcp/org.testeditor.rcp4.uatests/src/main/java/org/testeditor/fixture/swt/SWTFixture.java
@@ -124,16 +124,14 @@ public class SWTFixture {
 	}
 
 	/**
-	 * Waits for a dialog with a given title to show up and close. This method
-	 * is intended to be used for waiting for a progress dialog.
+	 * Waits for a dialog with a given title to show up.
 	 * 
 	 * @param title the title of the dialog
 	 */
 	@FixtureMethod
 	public void waitForDialog(String title) {
-		logger.info("Waiting for dialog with title='{}' to show up and close afterwards.", title);
+		logger.info("Waiting for dialog with title='{}' to open.", title);
 		bot.waitUntil(Conditions.shellIsActive(title));
-		bot.waitWhile(Conditions.shellIsActive(title));
 		logger.info("Finished waiting.");
 	}
 

--- a/rcp/org.testeditor.rcp4.uatests/src/main/java/org/testeditor/fixture/swt/SWTFixture.java
+++ b/rcp/org.testeditor.rcp4.uatests/src/main/java/org/testeditor/fixture/swt/SWTFixture.java
@@ -25,6 +25,7 @@ import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.Widget;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+import org.eclipse.swtbot.eclipse.finder.waits.Conditions;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
 import org.eclipse.swtbot.swt.finder.finders.ContextMenuHelper;
@@ -42,8 +43,8 @@ import org.testeditor.fixture.core.interaction.FixtureMethod;
  */
 public class SWTFixture {
 
-	Logger logger = LogManager.getLogger(SWTFixture.class);
-	SWTWorkbenchBot bot = new SWTWorkbenchBot();
+	private Logger logger = LogManager.getLogger(SWTFixture.class);
+	private SWTWorkbenchBot bot = new SWTWorkbenchBot();
 
 	/**
 	 * Method for debugging the AUT. A first implementation of an widget
@@ -113,15 +114,27 @@ public class SWTFixture {
 	 * 
 	 * @param seconds
 	 *            to wait until continue test.
-	 * @throws NumberFormatException
-	 *             on not parse able time.
 	 * @throws InterruptedException
 	 *             on test abort.
 	 */
 	@FixtureMethod
-	public void wait(String seconds) throws NumberFormatException, InterruptedException {
-		logger.info("wait for:  {}", seconds);
-		Thread.sleep(Long.parseLong(seconds) * 1000);
+	public void wait(int seconds) throws InterruptedException {
+		logger.info("Waiting for {} seconds.", seconds);
+		Thread.sleep(seconds * 1000);
+	}
+
+	/**
+	 * Waits for a dialog with a given title to show up and close. This method
+	 * is intended to be used for waiting for a progress dialog.
+	 * 
+	 * @param title the title of the dialog
+	 */
+	@FixtureMethod
+	public void waitForDialog(String title) {
+		logger.info("Waiting for dialog with title='{}' to show up and close afterwards.", title);
+		bot.waitUntil(Conditions.shellIsActive(title));
+		bot.waitWhile(Conditions.shellIsActive(title));
+		logger.info("Finished waiting.");
 	}
 
 	/**

--- a/rcp/org.testeditor.rcp4.uatests/src/test/java/org/testeditor/rcp4/createprojects/CreateWebProjectWithExampleTest.tcl
+++ b/rcp/org.testeditor.rcp4.uatests/src/test/java/org/testeditor/rcp4/createprojects/CreateWebProjectWithExampleTest.tcl
@@ -30,7 +30,8 @@ Setup:
 	- Select element "Web Fixture" in list <AvailableFixturesList>
 	- Click on <AddFixtureButton>
 	- Click on <FinishButton>
-
+	- Wait for dialog with title "Progress Information"
+	
 * Verify that the project is visible in the ui
 
 	Component: ProjectExplorer

--- a/rcp/org.testeditor.rcp4.uatests/src/test/java/org/testeditor/rcp4/swt.aml
+++ b/rcp/org.testeditor.rcp4.uatests/src/test/java/org/testeditor/rcp4/swt.aml
@@ -9,8 +9,13 @@ interaction type reportWidgets {
 
 interaction type wait {
 	label = "wait"
-	template = "wait " ${seconds} "seconds"
+	template = "Wait" ${seconds} "seconds"
 	method = SWTFixture.wait(seconds)
+}
+
+interaction type waitForDialog {
+	template = "Wait for dialog with title" ${title}
+	method = SWTFixture.waitForDialog(title)
 }
 
 interaction type isViewVisible {
@@ -74,9 +79,9 @@ element type List {
 }
 
 component type General {
-	interactions = reportWidgets, wait
+	interactions = reportWidgets, wait, waitForDialog
 }
 
 component type Dialog {
-	interactions = reportWidgets, wait	
+	interactions = reportWidgets, wait, waitForDialog
 }

--- a/rcp/org.testeditor.rcp4.uatests/src/test/java/org/testeditor/rcp4/testeditor.aml
+++ b/rcp/org.testeditor.rcp4.uatests/src/test/java/org/testeditor/rcp4/testeditor.aml
@@ -38,9 +38,9 @@ component HauptFenster is General {
 value-space projectmenues = #[ "New/Project...", "Open" ]
 
 component ProjectExplorer is General {
-	element ProjektBaum is TreeView {
+	element ProjektBaum is TreeView { // TODO english!
 		label = "Project Explorer"
-		locator ="Test Project Explorer"
+		locator = "Test Project Explorer"
 		executeContextMenuEntry.item restrict to projectmenues 
 	}
 }


### PR DESCRIPTION
Running the `uatests` on Windows fails as the `CreateWebProjectWithExampleTest` is not finished by the time the next test runs. This is because the test does not wait for the progress dialog to finish and so the next running test cannot clean the workspace. 