### PR TITLE
TE-405 activate JUnit result view after test execution

### DIFF
--- a/common/org.testeditor.dsl.common.ui/META-INF/MANIFEST.MF
+++ b/common/org.testeditor.dsl.common.ui/META-INF/MANIFEST.MF
@@ -18,5 +18,6 @@ Bundle-Activator: org.testeditor.dsl.common.ui.utils.Activator
 Bundle-ActivationPolicy: lazy
 Export-Package: org.testeditor.dsl.common.ui.gradle,
  org.testeditor.dsl.common.ui.utils,
- org.testeditor.dsl.common.ui.wizards
+ org.testeditor.dsl.common.ui.wizards,
+ org.testeditor.dsl.common.ui.workbench
 

--- a/common/org.testeditor.dsl.common.ui/src/org/testeditor/dsl/common/ui/workbench/PartHelper.xtend
+++ b/common/org.testeditor.dsl.common.ui/src/org/testeditor/dsl/common/ui/workbench/PartHelper.xtend
@@ -1,0 +1,14 @@
+package org.testeditor.dsl.common.ui.workbench
+
+import org.eclipse.ui.PlatformUI
+
+class PartHelper {
+
+	def void showView(String viewId) {
+		PlatformUI.workbench.display.syncExec [
+			val window = PlatformUI.workbench.workbenchWindows.head
+			window.activePage.showView(viewId)
+		]
+	}
+
+}

--- a/rcp/org.testeditor.rcp4.views.tcltestrun/src/org/testeditor/rcp4/views/tcltestrun/TclLauncherUi.xtend
+++ b/rcp/org.testeditor.rcp4.views.tcltestrun/src/org/testeditor/rcp4/views/tcltestrun/TclLauncherUi.xtend
@@ -34,6 +34,7 @@ import org.eclipse.ui.PlatformUI
 import org.eclipse.ui.dialogs.ElementListSelectionDialog
 import org.slf4j.LoggerFactory
 import org.testeditor.dsl.common.ui.utils.ProgressMonitorRunner
+import org.testeditor.dsl.common.ui.workbench.PartHelper
 import org.testeditor.rcp4.tcltestrun.TclGradleLauncher
 import org.testeditor.rcp4.tcltestrun.TclLauncher
 import org.testeditor.rcp4.tcltestrun.TclMavenLauncher
@@ -45,6 +46,8 @@ import org.testeditor.tcl.dsl.ui.util.TclIndexHelper
 import org.testeditor.tcl.dsl.ui.util.TclInjectorProvider
 
 class TclLauncherUi implements Launcher {
+	
+	static val RESULT_VIEW = "org.eclipse.jdt.junit.ResultView"
 	static val logger = LoggerFactory.getLogger(TclLauncherUi)
 
 	@Inject ProgressMonitorRunner progressRunner
@@ -55,6 +58,7 @@ class TclLauncherUi implements Launcher {
 	LaunchShortcutUtil launchShortcutUtil // since this class itself is instanciated by e4, this attribute has to be injected manually
 	Map<URI, ArrayList<TestCase>> tslIndex
 	@Inject TCLConsoleFactory consoleFactory
+	@Inject PartHelper partHelper
 
 	@Inject
 	new(TclInjectorProvider tclInjectorProvider) {
@@ -204,6 +208,7 @@ class TclLauncherUi implements Launcher {
 			testResultFileWriter.writeErrorFile(projectName, resultFile)
 		}
 		JUnitCore.importTestRunSession(resultFile)
+		partHelper.showView(RESULT_VIEW)
 	}
 
 }


### PR DESCRIPTION
After the test execution the result view (JUnit view) should be made visible.

Note that I tried using e4 mechanisms but the `EPartService` was very unhelpful as it complained about the non active workbench window. The workbench window is not active at this point, but we can use an existing one (which is not active) to open the view.