### PR TITLE
add missing bundle org.eclipse.xtext.common.types.shared to the product

### DIFF
--- a/rcp/org.testeditor.rcp4.product/testeditor.product
+++ b/rcp/org.testeditor.rcp4.product/testeditor.product
@@ -273,6 +273,7 @@
       <plugin id="org.eclipse.xtext.builder.standalone"/>
       <plugin id="org.eclipse.xtext.common.types"/>
       <plugin id="org.eclipse.xtext.common.types.edit"/>
+      <plugin id="org.eclipse.xtext.common.types.shared"/>
       <plugin id="org.eclipse.xtext.common.types.ui"/>
       <plugin id="org.eclipse.xtext.ecore"/>
       <plugin id="org.eclipse.xtext.generator"/>


### PR DESCRIPTION
This gives us a few benefits with the type handling (i.e. navigate from a generated Java file to the TCL).