### PR TITLE
TE-417 fix NPE in TclProposalProvider

### DIFF
--- a/tcl/org.testeditor.tcl.dsl.ui/src/org/testeditor/tcl/dsl/ui/contentassist/TclProposalProvider.xtend
+++ b/tcl/org.testeditor.tcl.dsl.ui/src/org/testeditor/tcl/dsl/ui/contentassist/TclProposalProvider.xtend
@@ -67,7 +67,7 @@ class TclProposalProvider extends AbstractTclProposalProvider {
 				// need to consider whether the completion should contain the '>' as well
 				val currentNode = context.currentNode
 				val includeClosingBracket = !currentNode.text.contains('>') &&
-					!currentNode.nextSibling.text.contains('>')
+					(currentNode.nextSibling === null || !currentNode.nextSibling.text.contains('>'))
 				possibleElements.forEach [
 					val displayString = '''«name»«IF !label.nullOrEmpty» - "«label»"«ENDIF» (type: «type.name»)'''
 					val proposal = '''<«name»«IF includeClosingBracket»>«ENDIF»'''


### PR DESCRIPTION
`currentNode.nextSibling` might be null if we're on the end of the document 