### PR TITLE
TE-438 allow question mark in TCL grammar

### DIFF
--- a/common/org.testeditor.dsl.common.testing/src/org/testeditor/dsl/common/testing/AssertionHelper.xtend
+++ b/common/org.testeditor.dsl.common.testing/src/org/testeditor/dsl/common/testing/AssertionHelper.xtend
@@ -13,6 +13,7 @@ import java.math.BigDecimal
 import java.util.regex.Pattern
 import javax.inject.Singleton
 import org.junit.Assert
+import org.junit.ComparisonFailure
 
 // TODO include the AssertionHelper via the JAR instead of copy&pasting it
 @Singleton
@@ -80,6 +81,12 @@ class AssertionHelper {
 					partialMatch: «actual.substring(0,lastIndex)»[«actual.substring(lastIndex)»]
 				«ENDIF»
 			''')
+		}
+	}
+
+	def void assertContains(String container, CharSequence substring) {
+		if (!container.contains(substring)) {
+			throw new ComparisonFailure("Could not find expected substring.", substring.toString, container)
 		}
 	}
 

--- a/common/org.testeditor.dsl.common.testing/src/org/testeditor/dsl/common/testing/DummyFixture.xtend
+++ b/common/org.testeditor.dsl.common.testing/src/org/testeditor/dsl/common/testing/DummyFixture.xtend
@@ -59,7 +59,12 @@ public class DummyFixture {
 	@FixtureMethod
 	def void clickOn(String locator, DummyLocatorStrategy locatorStragety) {
 	}
-	
+
+	@FixtureMethod
+	def boolean isVisible(String locator) {
+		return true
+	}
+
 	@FixtureMethod
 	def boolean getBool(String locator){
 		return true
@@ -104,6 +109,11 @@ public class DummyFixture {
 			method = «dummyFixture».getBool(element)
 		}
 		
+		interaction type isVisible {
+			template = "Is" ${element} "visible?"
+			method = «dummyFixture».isVisible(element)
+		}
+		
 		interaction type getList {
 			template = "Read list from" ${element}
 			method = «dummyFixture».getList(element)
@@ -120,7 +130,7 @@ public class DummyFixture {
 		}
 		
 		element type Label {
-			interactions = getList, getValue, getBool, getMap
+			interactions = getList, getValue, getBool, getMap, isVisible
 		}
 					
 		component GreetingApplication is Application {

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/SimpleTclGeneratorIntegrationTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/SimpleTclGeneratorIntegrationTest.xtend
@@ -200,4 +200,27 @@ class SimpleTclGeneratorIntegrationTest extends AbstractTclGeneratorIntegrationT
 		'''.toString)
 	}
 
+	@Test
+	def void testStepWithQuestionMark() {
+		// given
+		val tcl = '''
+			package com.example
+			
+			# SimpleTest
+			* Start the famous greetings application
+				Mask: GreetingApplication
+				- Is <bar> visible?
+		'''
+		val tclModel = parseTcl(tcl, "SimpleTest.tcl")
+
+		// when
+		val generatedCode = tclModel.generate
+
+		// then
+		generatedCode.assertContains('''
+		    «"    "»reporter.enter(TestRunReporter.SemanticUnit.STEP, "Is <bar> visible?");
+		    «"    "»dummyFixture.isVisible("label.greet");
+		'''.toString)
+	}
+
 }

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/formatter/TestStepFormatterTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/formatter/TestStepFormatterTest.xtend
@@ -4,6 +4,8 @@ import org.junit.Test
 
 class TestStepFormatterTest extends AbstractTclFormatterTest {
 
+	// TODO remove useNodeModel = false below once https://github.com/eclipse/xtext-core/issues/164 is resolved
+
 	val prefix = '''
 		package com.example
 		
@@ -67,6 +69,7 @@ class TestStepFormatterTest extends AbstractTclFormatterTest {
 	@Test
 	def void formatLineBreaksTml() {
 		assertFormatted [
+			useNodeModel = false
 			expectation = prefix + '''
 				* spec
 				
@@ -103,6 +106,7 @@ class TestStepFormatterTest extends AbstractTclFormatterTest {
 	@Test
 	def void formatWhitespacesTml() {
 		assertFormatted [
+			useNodeModel = false
 			expectation = prefix + '''
 				* spec
 
@@ -119,4 +123,28 @@ class TestStepFormatterTest extends AbstractTclFormatterTest {
 			'''
 		]
 	}
+
+	@Test
+	def void formatPunctuation() {
+		assertFormatted [
+			useNodeModel = false
+			expectation = prefix + '''
+				* spec
+
+					Component: component
+					- Is <Input> visible?
+					- Is <Input> visible?
+			'''
+
+			toBeFormatted = prefix + '''
+				* spec
+				
+					Component: component
+					- Is <Input> visible       ?
+					- Is <Input> visible
+					    ?
+			'''
+		]
+	}
+
 }

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/parser/TclModelParserTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/parser/TclModelParserTest.xtend
@@ -105,7 +105,7 @@ class TclModelParserTest extends AbstractTclTest {
 			* Start the famous greetings application
 				Mask: GreetingsApplication
 				- starte Anwendung "org.testeditor.swing.exammple.Greetings"
-				- gebe in <Eingabefeld> den Wert "Hello World" ein.
+				- gebe in <Eingabefeld> den Wert "Hello World" ein
 		'''
 		
 		// when
@@ -174,7 +174,7 @@ class TclModelParserTest extends AbstractTclTest {
 		test.steps.assertSingleElement => [
 			contexts.assertSingleElement.assertInstanceOf(ComponentTestStepContext) => [
 				steps.assertSingleElement.assertInstanceOf(TestStep) => [
-					contents.restoreString.assertEquals('Is Component visible ?')
+					contents.restoreString.assertEquals('Is Component visible?')
 				]
 			]
 		]

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/parser/TclModelParserTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/parser/TclModelParserTest.xtend
@@ -12,26 +12,26 @@
  *******************************************************************************/
 package org.testeditor.tcl.dsl.tests.parser
 
+import javax.inject.Inject
 import org.junit.Test
+import org.testeditor.dsl.common.testing.DslParseHelper
 import org.testeditor.tcl.AssertionTestStep
 import org.testeditor.tcl.ComparatorMatches
+import org.testeditor.tcl.Comparison
 import org.testeditor.tcl.ComponentTestStepContext
 import org.testeditor.tcl.MacroTestStepContext
+import org.testeditor.tcl.NullOrBoolCheck
 import org.testeditor.tcl.StepContentElement
+import org.testeditor.tcl.StringConstant
 import org.testeditor.tcl.TclPackage
 import org.testeditor.tcl.TestStep
 import org.testeditor.tcl.TestStepWithAssignment
 import org.testeditor.tcl.VariableReference
+import org.testeditor.tcl.dsl.tests.AbstractTclTest
+import org.testeditor.tcl.util.TclModelUtil
 import org.testeditor.tsl.StepContentVariable
 
 import static extension org.eclipse.xtext.nodemodel.util.NodeModelUtils.*
-import org.testeditor.tcl.NullOrBoolCheck
-import org.testeditor.tcl.Comparison
-import org.testeditor.tcl.StringConstant
-import javax.inject.Inject
-import org.testeditor.tcl.dsl.tests.AbstractTclTest
-import org.testeditor.tcl.util.TclModelUtil
-import org.testeditor.dsl.common.testing.DslParseHelper
 
 class TclModelParserTest extends AbstractTclTest {
 	
@@ -149,6 +149,32 @@ class TclModelParserTest extends AbstractTclTest {
 			emptyReferences.forEach[
 				assertInstanceOf(StepContentElement) => [
 					value.assertNull
+				]
+			]
+		]
+	}
+
+	@Test
+	def void parseTestStepWithQuestionMark() {
+		// given
+		val input = '''
+			package com.example
+			
+			# Test
+			
+			* Start
+				Mask: Demo
+				- Is Component visible?
+		'''
+		
+		// when
+		val test = parseTcl(input).test
+		
+		// then
+		test.steps.assertSingleElement => [
+			contexts.assertSingleElement.assertInstanceOf(ComponentTestStepContext) => [
+				steps.assertSingleElement.assertInstanceOf(TestStep) => [
+					contents.restoreString.assertEquals('Is Component visible ?')
 				]
 			]
 		]

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/util/TclModelUtilTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/util/TclModelUtilTest.xtend
@@ -51,6 +51,21 @@ class TclModelUtilTest extends AbstractParserTest {
 	}
 
 	@Test
+	def void restoreStringWithPunctuation() {
+		// given
+		val questionMark = parse('- Hello World?', grammarAccess.testStepRule, TestStep)
+		val questionMarkAndWhitespace = parse('- Hello World  ?', grammarAccess.testStepRule, TestStep)
+		val dot = parse('- Hello World  .', grammarAccess.testStepRule, TestStep)
+		val dotAndWhitespace = parse('- Hello World.', grammarAccess.testStepRule, TestStep)
+
+		// then
+		tclModelUtil.restoreString(questionMark.contents).assertEquals('Hello World?')
+		tclModelUtil.restoreString(questionMarkAndWhitespace.contents).assertEquals('Hello World?')
+		tclModelUtil.restoreString(dot.contents).assertEquals('Hello World.')
+		tclModelUtil.restoreString(dotAndWhitespace.contents).assertEquals('Hello World.')
+	}
+
+	@Test
 	def void testFindMacroDefinition() {
 		// given
 		val tmlModel = parseTcl( '''
@@ -83,28 +98,28 @@ class TclModelUtilTest extends AbstractParserTest {
 	def void testNormalizeTemplate() {
 		// given
 		val template = parse('''
-			"start with" ${somevar} "and more" ${othervar}
+			"start with" ${somevar} "and more" ${othervar} "?"
 		''', grammarAccess.templateRule, Template)
 
 		// when
 		val normalizedTemplate = tclModelUtil.normalize(template)
 
 		// then
-		normalizedTemplate.assertEquals('start with "" and more ""')
+		normalizedTemplate.assertEquals('start with "" and more ""?')
 	}
 
 	@Test
 	def void testNormalizeTestStep() {
 		// given
 		val testStep = parse('''
-			- start with "some" and more @other
+			- start with "some" and more @other ?
 		''', grammarAccess.testStepRule, TestStep)
 
 		// when
 		val normalizedTestStep = tclModelUtil.normalize(testStep)
 
 		// then
-		normalizedTestStep.assertEquals('start with "" and more ""')
+		normalizedTestStep.assertEquals('start with "" and more ""?')
 	}
 
 	@Test

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/Tcl.xtext
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/Tcl.xtext
@@ -104,10 +104,13 @@ MacroTestStepContext returns TestStepContext:
 
 TestStep:
 	{TestStep}
-	'-' contents+=StepContent* '.'?;
+	'-' contents+=StepContent* contents+=StepContentPunctuation?;
 
 AssertionTestStep:
 	'-' 'assert' assertExpression=(NullOrBoolCheck | FullComparison) '.'?;
+
+TestStepWithAssignment:
+	'-' variable=AssignmentVariable '=' contents+=StepContent* contents+=StepContentPunctuation?;
 
 /** expression order: Comparison -> (Addition -> Multiplication ->) Value
  *  which is reflecting the order of operator binding.
@@ -161,9 +164,6 @@ ComparatorLessThen:
 ComparatorGreaterThen:
 	{ComparatorGreaterThen} ('>' | negated?='<=');
 
-TestStepWithAssignment:
-	'-' variable=AssignmentVariable '=' contents+=StepContent* '.'?;
-
 AssignmentVariable:
 	name=ID;
 	
@@ -185,3 +185,7 @@ StepContentVariable returns tsl::StepContentVariable:
 StepContentElement hidden():
 	('<' value=ID '>') |
 	{StepContentElement} ('<>' | '<' WS+ '>');
+
+StepContentPunctuation:
+	value=('.'|'?')
+;

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/formatting2/TclFormatter.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/formatting2/TclFormatter.xtend
@@ -21,6 +21,7 @@ import org.testeditor.tcl.MacroCollection
 import org.testeditor.tcl.MacroTestStepContext
 import org.testeditor.tcl.SpecificationStepImplementation
 import org.testeditor.tcl.StepContentElement
+import org.testeditor.tcl.StepContentPunctuation
 import org.testeditor.tcl.TclModel
 import org.testeditor.tcl.TestCase
 import org.testeditor.tcl.TestCleanup
@@ -129,11 +130,14 @@ class TclFormatter extends XbaseFormatter {
 	def dispatch void format(TestStep testStep, extension IFormattableDocument document) {
 		testStep.regionFor.keyword("-").prepend[newLine]
 		testStep.contents.forEach[format]
-		testStep.regionFor.keyword(".").prepend[noSpace]
 	}
 
 	def dispatch void format(StepContentText stepContentText, extension IFormattableDocument document) {
 		stepContentText.regionFor.feature(TslPackage.Literals.STEP_CONTENT_VALUE__VALUE).prepend[oneSpace]
+	}
+
+	def dispatch void format(StepContentPunctuation punctuation, extension IFormattableDocument document) {
+		punctuation.regionFor.feature(TslPackage.Literals.STEP_CONTENT_VALUE__VALUE).prepend[noSpace]
 	}
 
 	def dispatch void format(StepContentVariable stepContentVariable, extension IFormattableDocument document) {

--- a/tcl/org.testeditor.tcl.model/model/tcl.xcore
+++ b/tcl/org.testeditor.tcl.model/model/tcl.xcore
@@ -24,6 +24,7 @@ import org.testeditor.aml.Variable
 import org.testeditor.dsl.common.NamedElement
 import org.testeditor.tsl.SpecificationStep
 import org.testeditor.tsl.StepContent
+import org.testeditor.tsl.StepContentText
 import org.testeditor.tsl.StepContentValue
 import org.testeditor.tsl.TestSpecification
 
@@ -148,6 +149,9 @@ class AssignmentVariable extends Variable {
 }
 
 class StepContentElement extends StepContentValue {
+}
+
+class StepContentPunctuation extends StepContentText {
 }
 
 abstract class Comparator {

--- a/tcl/org.testeditor.tcl.model/src/org/testeditor/tcl/util/TclModelUtil.xtend
+++ b/tcl/org.testeditor.tcl.model/src/org/testeditor/tcl/util/TclModelUtil.xtend
@@ -82,12 +82,14 @@ class TclModelUtil extends TslModelUtil {
 				StepContentElement: '''<«value»>'''
 				VariableReferenceMapAccess: '''@«variable?.name»."«key»"'''
 				VariableReference: '''@«variable?.name»'''
-				StepContentValue:
-					value
-				default:
-					'?'
+				StepContentValue: value
+				default: throw new IllegalArgumentException("Unhandled content: " + it)
 			}
-		].join(' ')
+		].join(' ').removeWhitespaceBeforePunctuation
+	}
+
+	private def String removeWhitespaceBeforePunctuation(String input) {
+		return input.replaceAll('''\s+(\.|\?)''', "$1")
 	}
 
 	def Macro findMacroDefinition(TestStep macroCallStep, MacroTestStepContext macroCallSite) {
@@ -118,7 +120,7 @@ class TclModelUtil extends TslModelUtil {
 				TemplateVariable: '""'
 				TemplateText: value.trim
 			}
-		].join(' ')
+		].join(' ').removeWhitespaceBeforePunctuation
 		return normalizedTemplate
 	}
 
@@ -128,9 +130,10 @@ class TclModelUtil extends TslModelUtil {
 				StepContentElement: '<>'
 				StepContentVariable: '""'
 				VariableReference: '""'
-				StepContentText: value.trim
+				StepContentValue: value.trim
+				default: throw new IllegalArgumentException("Unhandled content: " + it)
 			}
-		].join(' ')
+		].join(' ').removeWhitespaceBeforePunctuation
 		return normalizedStepContent
 	}
 


### PR DESCRIPTION
I ran into a small problem with the formatter as there is an Xtext bug (have filed it and added a TODO to the code). Formatting of the punctuation will currently not work in the editor.