### PR TITLE
Bugfix/cleanup

### DIFF
--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
@@ -342,14 +342,12 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 		output.append(assertCallBuilder.build(macroCallVariableResolver, step.assertExpression))
 	}
 
-	private def dispatch void toUnitTestCodeLine(TestStep step, ITreeAppendable output,
-		Iterable<TestStep> macroUseStack) {
-		logger.debug("generating code line for test step='{}'.", step.contents.restoreString)
-		val stepLog = step.contents.restoreString 
+	private def dispatch void toUnitTestCodeLine(TestStep step, ITreeAppendable output, Iterable<TestStep> macroUseStack) {
+		val stepLog = step.contents.restoreString
+		logger.debug("generating code line for test step='{}'.", stepLog)
 		val interaction = step.interaction
-		logger.debug("derived interaction='{}' for test step='{}'.",
-			interaction.defaultMethod?.operation?.qualifiedName, step.contents.restoreString)
 		if (interaction !== null) {
+			logger.debug("derived interaction with method='{}' for test step='{}'.", interaction.defaultMethod?.operation?.qualifiedName, stepLog)
 			val fixtureField = interaction.defaultMethod?.typeReference?.type?.fixtureFieldName
 			val operation = interaction.defaultMethod?.operation
 			if (fixtureField !== null && operation !== null) {
@@ -362,12 +360,11 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 				output.append('''// TODO interaction type '«interaction.name»' does not have a proper method reference''')
 			}
 		} else if (step.componentContext != null) {
-			output.append('''// TODO could not resolve '«step.componentContext.component.name»' - «step.contents.restoreString»''')
+			output.append('''// TODO could not resolve '«step.componentContext.component.name»' - «stepLog»''')
 		} else {
-			output.append('''// TODO could not resolve unknown component - «step.contents.restoreString»''')
+			output.append('''// TODO could not resolve unknown component - «stepLog»''')
 		}
 	}
-	
 	
 	private def void maybeCreateAssignment(TestStep step, JvmOperation operation, ITreeAppendable output, String stepLog) {
 		if (step instanceof TestStepWithAssignment) {

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TestRunReporterGenerator.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TestRunReporterGenerator.xtend
@@ -10,8 +10,8 @@ class TestRunReporterGenerator {
 	public def void appendReporterEnterCall(ITreeAppendable output, JvmTypeReferenceBuilder typeReferenceBuilder, SemanticUnit unit,
 		String message, String reporterInstanceVariableName) {
 		val escapedMessage=StringEscapeUtils.escapeJava(message.trim)
-		// all above STEP will add a newLine 
-		if (unit.ordinal < SemanticUnit.STEP.ordinal) {
+
+		if (unit.shouldPrintNewLine) {
 			output.newLine
 		}
 		if (typeReferenceBuilder == null) { // this happens in some testcases, in which this output is 
@@ -21,6 +21,10 @@ class TestRunReporterGenerator {
 			output.append('''«reporterInstanceVariableName».enter(''').append(typeRef.type).append('''.«unit.name», "«escapedMessage»");''').
 				newLine
 		}
+	}
+
+	private def boolean shouldPrintNewLine(SemanticUnit unit) {
+		return unit != SemanticUnit.STEP
 	}
 
 }


### PR DESCRIPTION
This is a cleanup/bugfix only.

TclJvmModelInferrer
- Reuse the result of `step.contents.restoreString` which is already stored in the variable `stepLog`
- Fix the `logger.debug("derived interactio...` statement which causes NPEs when interaction is null

TestRunReporterGenerator
- Don't use `Enum.ordinal()` for the decision if a line-break should be printed or not