### PR TITLE
improve build/release process

### DIFF
--- a/aml/org.testeditor.aml.dsl.ide/pom.xml
+++ b/aml/org.testeditor.aml.dsl.ide/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.aml.dsl.ide</artifactId>
 	<packaging>eclipse-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/aml/org.testeditor.aml.dsl.tests/pom.xml
+++ b/aml/org.testeditor.aml.dsl.tests/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.aml.dsl.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/aml/org.testeditor.aml.dsl.ui.tests/pom.xml
+++ b/aml/org.testeditor.aml.dsl.ui.tests/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.aml.dsl.ui.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/aml/org.testeditor.aml.dsl.ui/pom.xml
+++ b/aml/org.testeditor.aml.dsl.ui/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.aml.dsl.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/aml/org.testeditor.aml.sdk/pom.xml
+++ b/aml/org.testeditor.aml.sdk/pom.xml
@@ -13,4 +13,8 @@
 	<artifactId>org.testeditor.aml.sdk</artifactId>
 	<packaging>eclipse-feature</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 </project>

--- a/aml/pom.xml
+++ b/aml/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.aml.build</artifactId>
 	<packaging>pom</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<modules>
 		<module>org.testeditor.aml.model</module>
 		<module>org.testeditor.aml.dsl</module>

--- a/common/org.testeditor.dsl.common.testing/pom.xml
+++ b/common/org.testeditor.dsl.common.testing/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.dsl.common.testing</artifactId>
 	<packaging>eclipse-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/common/org.testeditor.dsl.common.tests/pom.xml
+++ b/common/org.testeditor.dsl.common.tests/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.dsl.common.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/common/org.testeditor.dsl.common.ui.tests/pom.xml
+++ b/common/org.testeditor.dsl.common.ui.tests/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.dsl.common.ui.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/common/org.testeditor.dsl.common.ui/pom.xml
+++ b/common/org.testeditor.dsl.common.ui/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.dsl.common.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/common/org.testeditor.logging/pom.xml
+++ b/common/org.testeditor.logging/pom.xml
@@ -15,6 +15,10 @@
 	<artifactId>org.testeditor.logging</artifactId>
 	<packaging>eclipse-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.common.build</artifactId>
 	<packaging>pom</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<modules>
 		<module>org.testeditor.dsl.common</module>
 		<module>org.testeditor.dsl.common.model</module>

--- a/legacy/org.testeditor.aml.legacy.feature/pom.xml
+++ b/legacy/org.testeditor.aml.legacy.feature/pom.xml
@@ -10,6 +10,10 @@
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<artifactId>org.testeditor.aml.legacy.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
 

--- a/legacy/org.testeditor.aml.legacy.importer.ui/pom.xml
+++ b/legacy/org.testeditor.aml.legacy.importer.ui/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.aml.legacy.importer.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/legacy/org.testeditor.aml.legacy.model/pom.xml
+++ b/legacy/org.testeditor.aml.legacy.model/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.aml.legacy.model</artifactId>
 	<packaging>eclipse-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.legacy.build</artifactId>
 	<packaging>pom</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<modules>
 		<module>org.testeditor.aml.legacy.model</module>
 		<module>org.testeditor.aml.legacy.importer.ui</module>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.build</artifactId>
 	<packaging>pom</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<modules>
 		<module>releng/org.testeditor.releng.parent</module>
 		<module>releng/org.testeditor.releng.parent.dsl</module>

--- a/rcp/org.testeditor.rcp4.bootstrap/pom.xml
+++ b/rcp/org.testeditor.rcp4.bootstrap/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.rcp4.bootstrap</artifactId>
 	<packaging>eclipse-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/rcp/org.testeditor.rcp4.feature/pom.xml
+++ b/rcp/org.testeditor.rcp4.feature/pom.xml
@@ -13,4 +13,8 @@
 	<artifactId>org.testeditor.rcp4.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 </project>

--- a/rcp/org.testeditor.rcp4.platform.feature/pom.xml
+++ b/rcp/org.testeditor.rcp4.platform.feature/pom.xml
@@ -13,4 +13,8 @@
 	<artifactId>org.testeditor.rcp4.platform.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 </project>

--- a/rcp/org.testeditor.rcp4.product/pom.xml
+++ b/rcp/org.testeditor.rcp4.product/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.rcp4.product</artifactId>
 	<packaging>eclipse-repository</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/rcp/org.testeditor.rcp4.tcltestrun.tests/pom.xml
+++ b/rcp/org.testeditor.rcp4.tcltestrun.tests/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.rcp4.tcltestrun.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -21,5 +25,6 @@
 			</plugin>
 		</plugins>
 	</build>
+
 </project>
 

--- a/rcp/org.testeditor.rcp4.tcltestrun/pom.xml
+++ b/rcp/org.testeditor.rcp4.tcltestrun/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.rcp4.tcltestrun</artifactId>
 	<packaging>eclipse-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -21,5 +25,6 @@
 			</plugin>
 		</plugins>
 	</build>
+
 </project>
 

--- a/rcp/org.testeditor.rcp4.tests/pom.xml
+++ b/rcp/org.testeditor.rcp4.tests/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.rcp4.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -21,4 +25,5 @@
 			</plugin>
 		</plugins>
 	</build>
+
 </project>

--- a/rcp/org.testeditor.rcp4.uatests/pom.xml
+++ b/rcp/org.testeditor.rcp4.uatests/pom.xml
@@ -14,6 +14,7 @@
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>
+		<deploy.skip>true</deploy.skip>
 		<testeditor.version>${project.version}</testeditor.version>
 		<testeditor.output>src-gen/test/java</testeditor.output>
 	</properties>

--- a/rcp/org.testeditor.rcp4.updatesite/pom.xml
+++ b/rcp/org.testeditor.rcp4.updatesite/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.rcp4.updatesite</artifactId>
 	<packaging>eclipse-update-site</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/rcp/org.testeditor.rcp4.views.projectexplorer.tests/pom.xml
+++ b/rcp/org.testeditor.rcp4.views.projectexplorer.tests/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.rcp4.views.projectexplorer.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/rcp/org.testeditor.rcp4.views.projectexplorer/pom.xml
+++ b/rcp/org.testeditor.rcp4.views.projectexplorer/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.rcp4.views.projectexplorer</artifactId>
 	<packaging>eclipse-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/rcp/org.testeditor.rcp4.views.tcltestrun.tests/pom.xml
+++ b/rcp/org.testeditor.rcp4.views.tcltestrun.tests/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.rcp4.views.tcltestrun.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/rcp/org.testeditor.rcp4.views.tcltestrun/pom.xml
+++ b/rcp/org.testeditor.rcp4.views.tcltestrun/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.rcp4.views.tcltestrun</artifactId>
 	<packaging>eclipse-plugin</packaging>
 	
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+	
 	<build>
 		<plugins>
 			<plugin>

--- a/rcp/org.testeditor.rcp4.views.teststepselection.tests/pom.xml
+++ b/rcp/org.testeditor.rcp4.views.teststepselection.tests/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.rcp4.views.teststepselector.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/rcp/org.testeditor.rcp4.views.teststepselection/pom.xml
+++ b/rcp/org.testeditor.rcp4.views.teststepselection/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.rcp4.views.teststepselector</artifactId>
 	<packaging>eclipse-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/rcp/org.testeditor.rcp4.views.testview/pom.xml
+++ b/rcp/org.testeditor.rcp4.views.testview/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.rcp4.views.testview</artifactId>
 	<packaging>eclipse-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/rcp/org.testeditor.rcp4/pom.xml
+++ b/rcp/org.testeditor.rcp4/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.rcp4</artifactId>
 	<packaging>eclipse-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -21,4 +25,5 @@
 			</plugin>
 		</plugins>
 	</build>
+
 </project>

--- a/rcp/pom.xml
+++ b/rcp/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.product</artifactId>
 	<packaging>pom</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<profiles>
 		<profile>
 			<id>product</id>
@@ -21,7 +25,6 @@
 			</modules>
 		</profile>
 	</profiles>
-
 
 	<modules>
 		<module>org.testeditor.rcp4.platform.feature</module>

--- a/releng/org.testeditor.releng.parent/pom.xml
+++ b/releng/org.testeditor.releng.parent/pom.xml
@@ -29,6 +29,7 @@
 		<xtext-target>file:///${basedir}/../../target-platform/org.testeditor.releng.target.updatesite/target/site</xtext-target>
 
 		<!-- other properties -->
+		<deploy.skip>false</deploy.skip>
 		<tycho-surefire-argline>-Xms40m -Xmx1G -Dorg.testeditor.ignoreConnectionState=true</tycho-surefire-argline>
 		<os-jvm-flags></os-jvm-flags>
 		<argLine>${tycho-surefire-argline} ${os-jvm-flags}</argLine>
@@ -171,6 +172,7 @@
 					<version>2.8.2</version>
 					<configuration>
 						<deployAtEnd>true</deployAtEnd>
+						<skip>${deploy.skip}</skip>
 						<updateReleaseInfo>false</updateReleaseInfo>
 					</configuration>
 				</plugin>

--- a/releng/org.testeditor.releng.parent/pom.xml
+++ b/releng/org.testeditor.releng.parent/pom.xml
@@ -15,7 +15,7 @@
 		<xtend.version>${xtext.version}</xtend.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<tycho-version>0.25.0</tycho-version>
+		<tycho-version>0.26.0</tycho-version>
 		<maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
 		<maven-resources-plugin.version>2.7</maven-resources-plugin.version>
 		<maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
@@ -57,6 +57,11 @@
 		</repository>
 	</repositories>
 
+	<scm>
+		<developerConnection>scm:git:https://github.com/test-editor/test-editor-xtext.git</developerConnection>
+		<url>https://github.com/test-editor/test-editor-xtext</url>
+	</scm>
+
     <distributionManagement>
         <repository>
             <id>bintray</id>
@@ -64,6 +69,13 @@
             <url>https://api.bintray.com/maven/test-editor/maven/test-editor/;publish=1</url>
         </repository>
     </distributionManagement>
+
+	<licenses>
+		<license>
+			<name>Eclipse Public License - v 1.0</name>
+			<url>https://www.eclipse.org/legal/epl-v10.html</url>
+		</license>
+	</licenses>
 
 	<build>
 		<pluginManagement>
@@ -213,6 +225,19 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-compiler-plugin</artifactId>
 				<version>${tycho-version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.0.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.jacoco</groupId>

--- a/target-platform/org.testeditor.releng.target.parent/pom.xml
+++ b/target-platform/org.testeditor.releng.target.parent/pom.xml
@@ -9,7 +9,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>0.25.0</tycho-version>
+		<tycho-version>0.26.0</tycho-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<deploy.skip>true</deploy.skip>
 	</properties>

--- a/target-platform/org.testeditor.releng.target.parent/pom.xml
+++ b/target-platform/org.testeditor.releng.target.parent/pom.xml
@@ -11,6 +11,7 @@
 	<properties>
 		<tycho-version>0.25.0</tycho-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<deploy.skip>true</deploy.skip>
 	</properties>
 
 	<repositories>
@@ -77,6 +78,18 @@
 	</repositories>
 
 	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>2.8.2</version>
+					<configuration>
+						<skip>${deploy.skip}</skip>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>

--- a/tcl/org.testeditor.tcl.dsl.ide/pom.xml
+++ b/tcl/org.testeditor.tcl.dsl.ide/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.tcl.dsl.ide</artifactId>
 	<packaging>eclipse-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/tcl/org.testeditor.tcl.dsl.tests/pom.xml
+++ b/tcl/org.testeditor.tcl.dsl.tests/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.tcl.dsl.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/tcl/org.testeditor.tcl.dsl.ui.tests/pom.xml
+++ b/tcl/org.testeditor.tcl.dsl.ui.tests/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.tcl.dsl.ui.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/tcl/org.testeditor.tcl.dsl.ui/pom.xml
+++ b/tcl/org.testeditor.tcl.dsl.ui/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.tcl.dsl.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/tcl/org.testeditor.tcl.sdk/pom.xml
+++ b/tcl/org.testeditor.tcl.sdk/pom.xml
@@ -13,4 +13,8 @@
 	<artifactId>org.testeditor.tcl.sdk</artifactId>
 	<packaging>eclipse-feature</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 </project>

--- a/tcl/pom.xml
+++ b/tcl/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.tcl.build</artifactId>
 	<packaging>pom</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<modules>
 		<module>org.testeditor.tcl.model</module>
 		<module>org.testeditor.tcl.dsl</module>

--- a/tsl/org.testeditor.tsl.dsl.ide/pom.xml
+++ b/tsl/org.testeditor.tsl.dsl.ide/pom.xml
@@ -7,8 +7,13 @@
 		<version>1.2.0-SNAPSHOT</version>
 		<relativePath>../../releng/org.testeditor.releng.parent</relativePath>
 	</parent>
+
 	<artifactId>org.testeditor.tsl.dsl.ide</artifactId>
 	<packaging>eclipse-plugin</packaging>
+
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
 
 	<build>
 		<plugins>

--- a/tsl/org.testeditor.tsl.dsl.tests/pom.xml
+++ b/tsl/org.testeditor.tsl.dsl.tests/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.tsl.dsl.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/tsl/org.testeditor.tsl.dsl.ui/pom.xml
+++ b/tsl/org.testeditor.tsl.dsl.ui/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.tsl.dsl.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/tsl/org.testeditor.tsl.dsl.web/pom.xml
+++ b/tsl/org.testeditor.tsl.dsl.web/pom.xml
@@ -12,6 +12,10 @@
 	<artifactId>org.testeditor.tsl.dsl.web</artifactId>
 	<packaging>war</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<resources>

--- a/tsl/org.testeditor.tsl.sdk/pom.xml
+++ b/tsl/org.testeditor.tsl.sdk/pom.xml
@@ -13,4 +13,8 @@
 	<artifactId>org.testeditor.tsl.sdk</artifactId>
 	<packaging>eclipse-feature</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 </project>

--- a/tsl/pom.xml
+++ b/tsl/pom.xml
@@ -13,6 +13,10 @@
 	<artifactId>org.testeditor.tsl.build</artifactId>
 	<packaging>pom</packaging>
 
+	<properties>
+		<deploy.skip>true</deploy.skip>
+	</properties>
+
 	<modules>
 		<module>org.testeditor.tsl.model</module>
 		<module>org.testeditor.tsl.dsl</module>


### PR DESCRIPTION
We should only deploy those Maven artifacts that are relevant to use on Bintray. Therefore, I added a `deploy.skip` attribute to those we don't need.

Made a sample deployment on a local nexus and it looked like this:

![nexus](https://cloud.githubusercontent.com/assets/1035300/20604867/ebeb0b9c-b268-11e6-898f-95b2ea562b91.png)

Also I improved the parent POM to include sources and a few more metadata and migrated to Tycho 0.26.0
