### PR TITLE
Fix build (remove maven-source-plugin)

### DIFF
--- a/releng/org.testeditor.releng.parent/pom.xml
+++ b/releng/org.testeditor.releng.parent/pom.xml
@@ -227,19 +227,6 @@
 				<version>${tycho-version}</version>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>3.0.1</version>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
 				<version>0.7.6.201602180812</version>


### PR DESCRIPTION
Apparently the application of the `maven-source-plugin` kills the Tycho product build...