### PR TITLE
TE-482 refactor TestStep to contain FixtureReference

### DIFF
--- a/tcl/org.testeditor.tcl.dsl.ide/src/org/testeditor/tcl/dsl/ide/highlighting/TclSemanticHighlightingCalculator.xtend
+++ b/tcl/org.testeditor.tcl.dsl.ide/src/org/testeditor/tcl/dsl/ide/highlighting/TclSemanticHighlightingCalculator.xtend
@@ -75,7 +75,7 @@ class TclSemanticHighlightingCalculator extends DefaultSemanticHighlightingCalcu
 
 	protected def void provideHighlightingForTestStepContext(TestStepContext context,
 		IHighlightedPositionAcceptor acceptor) {
-		context.steps.filter(TestStep).map[contents].flatten.forEach[provideHighlightingFor(acceptor)]
+		context.steps.filter(TestStep).map[fixtureReference.contents].flatten.forEach[provideHighlightingFor(acceptor)]
 	}
 
 	/**
@@ -103,7 +103,7 @@ class TclSemanticHighlightingCalculator extends DefaultSemanticHighlightingCalcu
 		for (specificationStep : test.steps) {
 			specificationStep.contents.forEach[provideHighlightingFor(acceptor)]
 			val testSteps = specificationStep.contexts.map[steps].flatten
-			val stepContents = testSteps.filter(TestStep).map[contents]
+			val stepContents = testSteps.filter(TestStep).map[fixtureReference.contents]
 			stepContents.filter(StepContentElement).forEach [
 				if (cancelIndicator.canceled) {
 					return

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/TclModelGenerator.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/TclModelGenerator.xtend
@@ -160,14 +160,20 @@ class TclModelGenerator {
 	}
 
 	def <T extends TestStep> T withElement(T me, String elementName) {
-		me.contents += tclFactory.createStepContentElement => [
+		if (me.fixtureReference === null) {
+			me.fixtureReference = tclFactory.createFixtureReference	
+		}
+		me.fixtureReference.contents += tclFactory.createStepContentElement => [
 			value = elementName
 		]
 		return me
 	}
 
 	def TestStep withReferenceToTemplateVariable(TestStep me, String variableReferenceName) {
-		me.contents += tclFactory.createVariableReference => [
+		if (me.fixtureReference === null) {
+			me.fixtureReference = tclFactory.createFixtureReference	
+		}
+		me.fixtureReference.contents += tclFactory.createVariableReference => [
 			variable = amlFactory.createTemplateVariable => [
 				name = variableReferenceName
 			]
@@ -176,25 +182,37 @@ class TclModelGenerator {
 	}
 
 	def TestStep withReferenceToVariable(TestStep me, Variable variable) {
-		me.contents += tclFactory.createVariableReference => [
+		if (me.fixtureReference === null) {
+			me.fixtureReference = tclFactory.createFixtureReference	
+		}
+		me.fixtureReference.contents += tclFactory.createVariableReference => [
 			it.variable = variable
 		]
 		return me
 	}
 
 	def TestStep withReference(TestStep me, VariableReference variableReference) {
-		me.contents += variableReference
+		if (me.fixtureReference === null) {
+			me.fixtureReference = tclFactory.createFixtureReference	
+		}
+		me.fixtureReference.contents += variableReference
 		return me
 	}
 
 	def TestStep withParameter(TestStep me, String parameter) {
-		me.contents += tslFactory.createStepContentVariable => [value = parameter]
+		if (me.fixtureReference === null) {
+			me.fixtureReference = tclFactory.createFixtureReference	
+		}
+		me.fixtureReference.contents += tslFactory.createStepContentVariable => [value = parameter]
 		return me
 	}
 
 	def TestStep withText(TestStep me, String ... texts) {
+		if (me.fixtureReference === null) {
+			me.fixtureReference = tclFactory.createFixtureReference	
+		}
 		return me => [
-			texts.forEach[text|contents += tslFactory.createStepContentText => [value = text]]
+			texts.forEach[text|fixtureReference.contents += tslFactory.createStepContentText => [value = text]]
 		]
 	}
 

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/parser/TclModelParserTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/parser/TclModelParserTest.xtend
@@ -118,10 +118,10 @@ class TclModelParserTest extends AbstractTclTest {
 				componentNode.text.trim.assertEquals('GreetingsApplication')
 				steps.assertSize(2)
 				steps.get(0).assertInstanceOf(TestStep) => [
-					contents.restoreString.assertEquals('starte Anwendung "org.testeditor.swing.exammple.Greetings"')	
+					fixtureReference.contents.restoreString.assertEquals('starte Anwendung "org.testeditor.swing.exammple.Greetings"')	
 				]
 				steps.get(1).assertInstanceOf(TestStep) => [
-					contents.restoreString.assertEquals('gebe in <Eingabefeld> den Wert "Hello World" ein')
+					fixtureReference.contents.restoreString.assertEquals('gebe in <Eingabefeld> den Wert "Hello World" ein')
 				]
 			]
 		]
@@ -136,7 +136,7 @@ class TclModelParserTest extends AbstractTclTest {
 			# Test
 			* Dummy step
 				Mask: Demo
-				- <> < 	> <
+				- some <> < 	> <
 				>
 		'''
 		
@@ -145,8 +145,8 @@ class TclModelParserTest extends AbstractTclTest {
 		
 		// then
 		test.steps.assertSingleElement.contexts.assertSingleElement.assertInstanceOf(ComponentTestStepContext) => [
-			val emptyReferences = steps.assertSingleElement.assertInstanceOf(TestStep).contents.assertSize(3)
-			emptyReferences.forEach[
+			val emptyReferences = steps.assertSingleElement.assertInstanceOf(TestStep).fixtureReference.contents.assertSize(4)
+			emptyReferences.drop(1).forEach[
 				assertInstanceOf(StepContentElement) => [
 					value.assertNull
 				]
@@ -174,7 +174,7 @@ class TclModelParserTest extends AbstractTclTest {
 		test.steps.assertSingleElement => [
 			contexts.assertSingleElement.assertInstanceOf(ComponentTestStepContext) => [
 				steps.assertSingleElement.assertInstanceOf(TestStep) => [
-					contents.restoreString.assertEquals('Is Component visible?')
+					fixtureReference.contents.restoreString.assertEquals('Is Component visible?')
 				]
 			]
 		]
@@ -200,7 +200,7 @@ class TclModelParserTest extends AbstractTclTest {
 			contexts.assertSingleElement.assertInstanceOf(ComponentTestStepContext) => [
 				steps.assertSingleElement.assertInstanceOf(TestStepWithAssignment) => [
 					variable.name.assertEquals('hello')
-					contents.restoreString.assertEquals('Lese den Text von <Input>')
+					fixtureReference.contents.restoreString.assertEquals('Lese den Text von <Input>')
 				]
 			]
 		]
@@ -289,10 +289,10 @@ class TclModelParserTest extends AbstractTclTest {
 			contexts.assertSingleElement.assertInstanceOf(MacroTestStepContext) => [
 				steps.assertSize(2)
 				steps.head.assertInstanceOf(TestStep) => [
-					contents.restoreString.assertMatches('template execute with "param" as a and "param2"')
+					fixtureReference.contents.restoreString.assertMatches('template execute with "param" as a and "param2"')
 				]
 				steps.last.assertInstanceOf(TestStep) => [
-					contents.restoreString.assertMatches('second template')
+					fixtureReference.contents.restoreString.assertMatches('second template')
 				]
 			]
 		]

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/validation/TclParameterUsageValidatorTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/validation/TclParameterUsageValidatorTest.xtend
@@ -208,7 +208,7 @@ class TclParameterUsageValidatorTest extends AbstractParserTestWithDummyComponen
 		tclModel.addToResourceSet('test.tcl')
 		
 		// when then
-		validator.assertError(tclModel, TEST_STEP, TclValidator.INVALID_VAR_DEREF) // since assignment must take place before usage!
+		validator.assertError(tclModel, FIXTURE_REFERENCE, TclValidator.INVALID_VAR_DEREF) // since assignment must take place before usage!
 	}
 	
 	@Test
@@ -226,7 +226,7 @@ class TclParameterUsageValidatorTest extends AbstractParserTestWithDummyComponen
 		tclModel.addToResourceSet('MyTest.tcl')
 		
 		// when then
-		validator.assertError(tclModel, TEST_STEP, TclValidator.INVALID_PARAMETER_TYPE)
+		validator.assertError(tclModel, FIXTURE_REFERENCE, TclValidator.INVALID_PARAMETER_TYPE)
 	}
 	
 	@Test
@@ -265,7 +265,7 @@ class TclParameterUsageValidatorTest extends AbstractParserTestWithDummyComponen
 		tclModel.addToResourceSet('MyTest.tcl')
 		
 		// when then
-		validator.assertError(tclModel, TEST_STEP, TclValidator.INVALID_TYPED_VAR_DEREF) // since long is expected, and map is provided
+		validator.assertError(tclModel, FIXTURE_REFERENCE, TclValidator.INVALID_TYPED_VAR_DEREF) // since long is expected, and map is provided
 	}
 	
 	@Test

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/validation/TclVarUsageValidatorTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/validation/TclVarUsageValidatorTest.xtend
@@ -68,7 +68,7 @@ class TclVarUsageValidatorTest extends AbstractParserTestWithDummyComponent {
 						steps += assignmentStep
 						steps += testStep("start") => [
 							// variable map access is valid: declared first, usage within same test case, type of variable is Map
-							contents += mappedReference(assignmentStep.variable)
+							fixtureReference.contents += mappedReference(assignmentStep.variable)
 						]
 					]
 				]
@@ -154,7 +154,7 @@ class TclVarUsageValidatorTest extends AbstractParserTestWithDummyComponent {
 		tclModel.addToResourceSet('Test.tml')
 
 		// then
-		tclModel.assertError(TEST_STEP, TclValidator.INVALID_VAR_DEREF)
+		tclModel.assertError(FIXTURE_REFERENCE, TclValidator.INVALID_VAR_DEREF)
 
 	}
 
@@ -214,7 +214,7 @@ class TclVarUsageValidatorTest extends AbstractParserTestWithDummyComponent {
 						steps += assignmentStep
 						steps += testStep("start") => [
 							// map access is illegal, since variable is of type String
-							contents += mappedReference(assignmentStep.variable) => [ key = "some" ]
+							fixtureReference.contents += mappedReference(assignmentStep.variable) => [ key = "some" ]
 						]
 					]
 				]
@@ -223,7 +223,7 @@ class TclVarUsageValidatorTest extends AbstractParserTestWithDummyComponent {
 		tclModel.addToResourceSet('Test.tcl')
 		
 		// then
-		tclModel.assertError(TEST_STEP, TclValidator.INVALID_MAP_ACCESS)
+		tclModel.assertError(FIXTURE_REFERENCE, TclValidator.INVALID_MAP_ACCESS)
 	}
 
 	@Test

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/util/TclModelUtilTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/util/TclModelUtilTest.xtend
@@ -36,14 +36,14 @@ class TclModelUtilTest extends AbstractParserTest {
 	@Test
 	def void testRestoreString() {
 		// given
-		val testStep = parse('-  <hello>     world "ohoh"   @xyz', grammarAccess.testStepRule, TestStep)
-		testStep.contents.get(3).assertInstanceOf(VariableReference)
+		val testStep = parse('-  some <hello>     world "ohoh"   @xyz', grammarAccess.testStepRule, TestStep)
+		testStep.fixtureReference.contents.get(4).assertInstanceOf(VariableReference)
 
 		// when
-		val result = tclModelUtil.restoreString(testStep.contents)
+		val result = tclModelUtil.restoreString(testStep.fixtureReference.contents)
 
 		// then
-		result.assertMatches('<hello> world "ohoh" @') // empty variable reference name, since the reference is null
+		result.assertMatches('some <hello> world "ohoh" @') // empty variable reference name, since the reference is null
 	}
 
 	@Test
@@ -55,10 +55,10 @@ class TclModelUtilTest extends AbstractParserTest {
 		val dotAndWhitespace = parse('- Hello World.', grammarAccess.testStepRule, TestStep)
 
 		// when, then
-		tclModelUtil.restoreString(questionMark.contents).assertEquals('Hello World?')
-		tclModelUtil.restoreString(questionMarkAndWhitespace.contents).assertEquals('Hello World?')
-		tclModelUtil.restoreString(dot.contents).assertEquals('Hello World.')
-		tclModelUtil.restoreString(dotAndWhitespace.contents).assertEquals('Hello World.')
+		tclModelUtil.restoreString(questionMark.fixtureReference.contents).assertEquals('Hello World?')
+		tclModelUtil.restoreString(questionMarkAndWhitespace.fixtureReference.contents).assertEquals('Hello World?')
+		tclModelUtil.restoreString(dot.fixtureReference.contents).assertEquals('Hello World.')
+		tclModelUtil.restoreString(dotAndWhitespace.fixtureReference.contents).assertEquals('Hello World.')
 	}
 
 	@Test
@@ -127,8 +127,8 @@ class TclModelUtilTest extends AbstractParserTest {
 		val template = parse('''
 			"start with" ${somevar} "and more" ${othervar}
 		''', grammarAccess.templateRule, Template)
-		val someValue = testStep.contents.filter(StepContentVariable).head
-		val otherRef = testStep.contents.filter(VariableReference).head
+		val someValue = testStep.fixtureReference.contents.filter(StepContentVariable).head
+		val otherRef = testStep.fixtureReference.contents.filter(VariableReference).head
 		val somevar = template.contents.get(1)
 		val othervar = template.contents.get(3)
 

--- a/tcl/org.testeditor.tcl.dsl.ui/src/org/testeditor/tcl/dsl/ui/editor/DropUtils.xtend
+++ b/tcl/org.testeditor.tcl.dsl.ui/src/org/testeditor/tcl/dsl/ui/editor/DropUtils.xtend
@@ -78,17 +78,20 @@ class DropUtils {
 				TemplateText: {
 					val stepContentText = tslFactory.createStepContentText
 					stepContentText.value = value
-					newTestStep.contents.add(stepContentText)
+					if (newTestStep.fixtureReference === null) {
+						newTestStep.fixtureReference = tclFactory.createFixtureReference
+					}
+					newTestStep.fixtureReference.contents.add(stepContentText)
 				}
 				TemplateVariable: {
 					if (name != 'element') {
 						val stepContentVariable = tslFactory.createStepContentVariable
 						stepContentVariable.value = name
-						newTestStep.contents.add(stepContentVariable)
+						newTestStep.fixtureReference.contents.add(stepContentVariable)
 					} else {
 						val stepContentElement = tclFactory.createStepContentElement
 						stepContentElement.value = componentElement.name
-						newTestStep.contents.add(stepContentElement)
+						newTestStep.fixtureReference.contents.add(stepContentElement)
 					}
 				}
 				default:

--- a/tcl/org.testeditor.tcl.dsl.ui/src/org/testeditor/tcl/dsl/ui/labeling/TclLabelProvider.xtend
+++ b/tcl/org.testeditor.tcl.dsl.ui/src/org/testeditor/tcl/dsl/ui/labeling/TclLabelProvider.xtend
@@ -41,6 +41,6 @@ class TclLabelProvider extends XbaseLabelProvider {
 	}
 
 	def text(TestStep testStep) {
-		return testStep.contents.restoreString
+		return testStep.fixtureReference.contents.restoreString
 	}
 }

--- a/tcl/org.testeditor.tcl.dsl.ui/src/org/testeditor/tcl/dsl/ui/navigation/TclHyperLinkHelper.xtend
+++ b/tcl/org.testeditor.tcl.dsl.ui/src/org/testeditor/tcl/dsl/ui/navigation/TclHyperLinkHelper.xtend
@@ -48,10 +48,10 @@ class TclHyperLinkHelper extends XbaseHyperLinkHelper {
 	protected def dispatch void createHyperlinks(TestStep testStep, IHyperlinkAcceptor acceptor) {
 		val interaction = testStep.interaction
 		if (interaction !== null) {
-			testStep.createHyperlinkTo(TEST_STEP__CONTENTS, interaction.template, acceptor)
+			testStep.createHyperlinkTo(FIXTURE_REFERENCE__CONTENTS, interaction.template, acceptor)
 		} else if (testStep.hasMacroContext) {
 			val macroTemplate = testStep.findMacroDefinition(testStep.macroContext)?.template
-			testStep.createHyperlinkTo(TEST_STEP__CONTENTS, macroTemplate, acceptor)
+			testStep.createHyperlinkTo(FIXTURE_REFERENCE__CONTENTS, macroTemplate, acceptor)
 		}
 	}
 

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/Tcl.xtext
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/Tcl.xtext
@@ -107,14 +107,17 @@ MacroTestStepContext returns TestStepContext:
  */
 TestStep:
 	{TestStep}
-	'-' contents+=StepContent* contents+=StepContentPunctuation?;
+	'-' fixtureReference=FixtureReference?;
 
 AssertionTestStep:
 	'-' 'assert' assertExpression=(NullOrBoolCheck | FullComparison) '.'?;
 
 TestStepWithAssignment:
-	'-' variable=AssignmentVariable '=' contents+=StepContent* contents+=StepContentPunctuation?;
+	'-' variable=AssignmentVariable '=' fixtureReference=FixtureReference;
 
+FixtureReference:
+	contents+=StepContentText contents+=StepContent* contents+=StepContentPunctuation?;
+    
 /** expression order: Comparison -> (Addition -> Multiplication ->) Value
  *  which is reflecting the order of operator binding.
  * 

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/formatting2/TclFormatter.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/formatting2/TclFormatter.xtend
@@ -131,7 +131,7 @@ class TclFormatter extends XbaseFormatter {
 	def dispatch void format(AbstractTestStep testStep, extension IFormattableDocument document) {
 		testStep.regionFor.keyword("-").prepend[newLine]
 		if (testStep instanceof TestStep) {
-			testStep.contents.forEach[format]
+			testStep.fixtureReference.contents.forEach[format]
 			testStep.regionFor.keyword(".").prepend[noSpace]
 		}
 	}

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/SimpleTypeComputer.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/SimpleTypeComputer.xtend
@@ -43,7 +43,7 @@ class SimpleTypeComputer {
 
 		// Get variable usages with their types, last usage wins (validation should make sure it's only used once)
 		for (context : macro.contexts) {
-			val stepsWithVariableReferences = context.steps.filter(TestStep).filter[!contents.filter(VariableReference).empty]
+			val stepsWithVariableReferences = context.steps.filter(TestStep).filter[!fixtureReference.contents.filter(VariableReference).empty]
 			for (step : stepsWithVariableReferences) {
 				result.putAll(getVariablesWithTypes(step, variables))
 			}

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
@@ -382,7 +382,7 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 	}
 
 	private def dispatch void toUnitTestCodeLine(TestStep step, ITreeAppendable output) {
-		val stepLog = step.contents.restoreString
+		val stepLog = step.fixtureReference.contents.restoreString
 		logger.debug("generating code line for test step='{}'.", stepLog)
 		val interaction = step.interaction
    		
@@ -393,7 +393,7 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 			if (fixtureField !== null && operation !== null) {
 				step.maybeCreateAssignment(operation, output, stepLog)
 				output.trace(interaction.defaultMethod) => [ 
-					step.contents.filter(VariableReference).forEach [
+					step.fixtureReference.contents.filter(VariableReference).forEach [
 						val expectedType = tclTypeValidationUtil.getExpectedType(it, step, interaction) 
 						if(coercionNecessary(interaction, expectedType)) {
 							val coercionCheck = generateCoercionCheck(interaction, expectedType)
@@ -480,14 +480,14 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 	} 
 
 	private def void generateMacroCall(TestStep step, MacroTestStepContext context, ITreeAppendable output) {
-		val stepLog = step.contents.restoreString
+		val stepLog = step.fixtureReference.contents.restoreString
 		logger.debug("generating code line for macro test step='{}'.", stepLog)
 		output.newLine
 		output.append('''// - «stepLog»''')
 		output.newLine
 		val macro = step.findMacroDefinition(context)
 		if (macro !== null) {
-			step.contents.filter(VariableReference).forEach [
+			step.fixtureReference.contents.filter(VariableReference).forEach [
 				val expectedType = tclTypeValidationUtil.getExpectedType(it, step, macro) 
 				if (coercionNecessary(macro, expectedType)) {
 					val coercionCheck = generateCoercionCheck(macro, expectedType)

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/validation/TclValidator.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/validation/TclValidator.xtend
@@ -111,7 +111,7 @@ class TclValidator extends AbstractTclValidator {
 		if (!(testStep instanceof AssertionTestStep) && testStep.hasComponentContext) {
 			val method = testStep.interaction?.defaultMethod
 			if ((method == null ) || (method.operation == null) || (method.typeReference?.type == null)) {
-				info("test step could not resolve fixture", TclPackage.Literals.TEST_STEP__CONTENTS, MISSING_FIXTURE)
+				info("test step could not resolve fixture", TclPackage.Literals.TEST_STEP__FIXTURE_REFERENCE, MISSING_FIXTURE)
 			}
 		}
 	}
@@ -122,7 +122,7 @@ class TclValidator extends AbstractTclValidator {
 			val normalizedTeststep = testStep.normalize
 			val macroCollection = testStep.macroContext.macroCollection
 			if (!macroCollection.macros.exists[template.normalize == normalizedTeststep]) {
-				warning("test step could not resolve macro usage", TclPackage.Literals.TEST_STEP__CONTENTS,
+				warning("test step could not resolve macro usage", TclPackage.Literals.TEST_STEP__FIXTURE_REFERENCE,
 					MISSING_MACRO)
 			}
 		}
@@ -161,7 +161,7 @@ class TclValidator extends AbstractTclValidator {
 	private def dispatch void checkAllReferencedVariablesAreKnown(TestStep step, Set<String> knownVariableNames,
 		String errorMessage) {
 		// contents are indexed so that errors can be set to the precise location (index within the contents)
-		val erroneousIndexedStepContents = step.contents.indexed.filterValue(VariableReference).filter [
+		val erroneousIndexedStepContents = step.fixtureReference.contents.indexed.filterValue(VariableReference).filter [
 			!knownVariableNames.contains(value.variable.name)
 		]
 		erroneousIndexedStepContents.forEach [
@@ -362,7 +362,7 @@ class TclValidator extends AbstractTclValidator {
 		Map<String, JvmTypeReference> declaredVariablesTypeMap, TestStepContext context,
 		Set<String> excludedVariableNames) {
 		// build this variables index to be able to correctly issue an error on the element by index
-		val variablesIndexed = step.contents.indexed.filter [!(value instanceof StepContentText)]
+		val variablesIndexed = step.fixtureReference.contents.indexed.filter [!(value instanceof StepContentText)]
 		val variableReferencesIndexed = variablesIndexed.filterValue(VariableReference).filter [
 			!excludedVariableNames.contains(value.variable.name)
 		]
@@ -455,7 +455,7 @@ class TclValidator extends AbstractTclValidator {
 	
 	private def void checkStepContentVariableTypeInParameterPosition(TestStep step, InteractionType interaction) {
 		// check only StepContentVariable, since variable references are already tested by ...
-		val callParameters=step.contents.indexed.filterValue(StepContentVariable)
+		val callParameters=step.fixtureReference.contents.indexed.filterValue(StepContentVariable)
 		val definitionParameterTypePairs = simpleTypeComputer.getVariablesWithTypes(interaction)		
 		callParameters.forEach [ contentIndexPair |
 			val content = contentIndexPair.value
@@ -484,7 +484,7 @@ class TclValidator extends AbstractTclValidator {
 		contentTemplateVarmap.filterKey(StepContentVariable).forEach [ content, templateVar |
 			val expectedType = templateParameterTypeMap.get(templateVar)
 			expectedType.ifPresent [
-				val contentIndex = step.contents.indexOfFirst(content)
+				val contentIndex = step.fixtureReference.contents.indexOfFirst(content)
 				val expectedTypeQualName = expectedType.get.qualifiedName
 				if (expectedTypeQualName.equals(long.name)) {
 					content.checkThatUseAsTypedLongIsOk(contentIndex)

--- a/tcl/org.testeditor.tcl.model/model/tcl.xcore
+++ b/tcl/org.testeditor.tcl.model/model/tcl.xcore
@@ -104,7 +104,11 @@ abstract class AbstractTestStep {
 }
 
 class TestStep extends AbstractTestStep {
-	contains StepContent[0..*] contents
+	contains FixtureReference fixtureReference
+}
+
+class FixtureReference {
+	contains StepContent[0..*] contents	
 }
 
 class AssertionTestStep extends AbstractTestStep {

--- a/tcl/org.testeditor.tcl.model/src/org/testeditor/tcl/util/TclModelUtil.xtend
+++ b/tcl/org.testeditor.tcl.model/src/org/testeditor/tcl/util/TclModelUtil.xtend
@@ -124,7 +124,7 @@ class TclModelUtil extends TslModelUtil {
 	}
 
 	def String normalize(TestStep step) {
-		val normalizedStepContent = step.contents.map [
+		val normalizedStepContent = step.fixtureReference.contents.map [
 			switch (it) {
 				StepContentElement: '<>'
 				StepContentVariable: '""'
@@ -141,11 +141,11 @@ class TclModelUtil extends TslModelUtil {
 	 * The result is ordered by appearance in the {@link TestStep}.
 	 */
 	def LinkedHashMap<StepContent, TemplateVariable> getStepContentToTemplateVariablesMapping(TestStep step, Template template) {
-		val stepContentElements = step.contents.filter[!(it instanceof StepContentText)]
+		val stepContentElements = step.fixtureReference.contents.filter[!(it instanceof StepContentText)]
 		val templateVariables = template.contents.filter(TemplateVariable)
 		if (stepContentElements.size !== templateVariables.size) {
 			val message = '''
-				Variables for '«step.contents.restoreString»' did not match the parameters of template '«template.normalize»' (normalized).
+				Variables for '«step.fixtureReference.contents.restoreString»' did not match the parameters of template '«template.normalize»' (normalized).
 			'''
 			throw new IllegalArgumentException(message)
 		}
@@ -157,7 +157,7 @@ class TclModelUtil extends TslModelUtil {
 	}
 	
 	def ComponentElement getComponentElement(TestStep testStep) {
-		val contentElement = testStep.contents.filter(StepContentElement).head
+		val contentElement = testStep.fixtureReference.contents.filter(StepContentElement).head
 		if (contentElement !== null) {
 			val component = testStep.componentContext?.component
 			return component?.elements?.findFirst[name == contentElement.value]
@@ -229,7 +229,7 @@ class TclModelUtil extends TslModelUtil {
 	 * get all variables, variable references and elements that are used as parameters in this test step
 	 */
 	def Iterable<StepContent> getStepContentVariables(TestStep step) {
-		return step.contents.filter [!(it instanceof StepContentText)]
+		return step.fixtureReference.contents.filter [!(it instanceof StepContentText)]
 	}
 
 	def SpecificationStep getSpecificationStep(SpecificationStepImplementation stepImplementation) {
@@ -269,7 +269,7 @@ class TclModelUtil extends TslModelUtil {
 	def dispatch boolean makesUseOfVariablesViaReference(TestStepContext context, Set<String> variables) {
 		return context.steps.exists [
 			switch (it) {
-				TestStep: contents.exists[makesUseOfVariablesViaReference(variables)]
+				TestStep: fixtureReference.contents.exists[makesUseOfVariablesViaReference(variables)]
 				AssertionTestStep: assertExpression.makesUseOfVariablesViaReference(variables)
 				default: throw new RuntimeException('''Unknown TestStep type='«class.canonicalName»'.''')
 			}


### PR DESCRIPTION
first of a couple of pull requests:
Model/Parser Refactoring that does not change behaviour.
There however is a minor correction:
References to fixtures (e.g. in TestStep) must start with StepContentText (see definition of Template within Aml.xtext). 
Before this correction the parser would allow illegal references, e.g. starting with a variable.