### PR TITLE
Bugfix/injection bundle cleanup

### DIFF
--- a/aml/org.testeditor.aml.dsl.ide/META-INF/MANIFEST.MF
+++ b/aml/org.testeditor.aml.dsl.ide/META-INF/MANIFEST.MF
@@ -8,4 +8,4 @@ Export-Package: org.testeditor.aml.dsl.ide.contentassist.antlr.internal,
 Require-Bundle: org.testeditor.aml.dsl,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.ide
-
+Import-Package: javax.inject;version="1.0.0"

--- a/aml/org.testeditor.aml.dsl.tests/META-INF/MANIFEST.MF
+++ b/aml/org.testeditor.aml.dsl.tests/META-INF/MANIFEST.MF
@@ -24,7 +24,8 @@ Import-Package: com.google.inject,
  org.eclipse.xtext.validation,
  org.junit,
  org.junit.runner,
- org.junit.runners
+ org.junit.runners,
+ javax.inject;version="1.0.0"
 Export-Package: org.testeditor.aml.dsl.tests,
  org.testeditor.aml.dsl.tests.parser,
  org.testeditor.aml.dsl.tests.common

--- a/aml/org.testeditor.aml.dsl.ui/META-INF/MANIFEST.MF
+++ b/aml/org.testeditor.aml.dsl.ui/META-INF/MANIFEST.MF
@@ -29,7 +29,8 @@ Require-Bundle: org.testeditor.dsl.common,
  org.eclipse.jdt.ui,
  org.eclipse.xtend.lib;resolution:=optional,
  org.testeditor.aml.dsl.ide
-Import-Package: org.apache.log4j
+Import-Package: org.apache.log4j,
+ javax.inject;version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.testeditor.aml.dsl.ui,
  org.testeditor.aml.dsl.ui.contentassist,

--- a/aml/org.testeditor.aml.dsl.ui/src/org/testeditor/aml/dsl/ui/labeling/AmlLabelProvider.xtend
+++ b/aml/org.testeditor.aml.dsl.ui/src/org/testeditor/aml/dsl/ui/labeling/AmlLabelProvider.xtend
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.testeditor.aml.dsl.ui.labeling
 
-import com.google.inject.Inject
+import javax.inject.Inject
 import org.eclipse.emf.edit.ui.provider.AdapterFactoryLabelProvider
 import org.eclipse.xtext.ui.label.DefaultEObjectLabelProvider
 import org.testeditor.aml.Template

--- a/aml/org.testeditor.aml.dsl/META-INF/MANIFEST.MF
+++ b/aml/org.testeditor.aml.dsl/META-INF/MANIFEST.MF
@@ -20,7 +20,8 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.osgi,
  org.eclipse.xtend.lib,
  org.testeditor.dsl.common
-Import-Package: org.apache.log4j
+Import-Package: org.apache.log4j,
+ javax.inject;version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.testeditor.aml.dsl,
  org.testeditor.aml.dsl.formatting2,

--- a/common/org.testeditor.dsl.common.testing/META-INF/MANIFEST.MF
+++ b/common/org.testeditor.dsl.common.testing/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.core.resources,
  org.testeditor.aml.dsl,
  org.junit;bundle-version="4.12.0",
  org.testeditor.dsl.common.model
-Import-Package: javax.inject,
+Import-Package: javax.inject;version="1.0.0",
  org.hamcrest.core,
  org.slf4j,
  org.testeditor.tcl,

--- a/common/org.testeditor.dsl.common.tests/META-INF/MANIFEST.MF
+++ b/common/org.testeditor.dsl.common.tests/META-INF/MANIFEST.MF
@@ -4,8 +4,9 @@ Bundle-Name: Tests
 Bundle-SymbolicName: org.testeditor.dsl.common.tests
 Bundle-Version: 1.6.0.qualifier
 Bundle-Vendor: Signal Iduna Corporation
-Fragment-Host: org.testeditor.dsl.common;bundle-version="1.0.0"
+Fragment-Host: org.testeditor.dsl.common
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.junit,
- org.junit.rules;version="4.12.0"
+ org.junit.rules;version="4.12.0",
+ javax.inject;version="1.0.0"
 Require-Bundle: org.testeditor.dsl.common.testing

--- a/common/org.testeditor.dsl.common.ui.tests/META-INF/MANIFEST.MF
+++ b/common/org.testeditor.dsl.common.ui.tests/META-INF/MANIFEST.MF
@@ -16,5 +16,4 @@ Require-Bundle: org.eclipse.xtend.lib.macro,
  org.testeditor.tcl.dsl,
  org.testeditor.tcl.dsl.ui,
  org.eclipse.core.filesystem
-Import-Package: javax.inject
-
+Import-Package: javax.inject;version="1.0.0"

--- a/common/org.testeditor.dsl.common.ui/META-INF/MANIFEST.MF
+++ b/common/org.testeditor.dsl.common.ui/META-INF/MANIFEST.MF
@@ -24,3 +24,4 @@ Export-Package: org.testeditor.dsl.common.ui.refactoring,
  org.testeditor.dsl.common.ui.utils,
  org.testeditor.dsl.common.ui.wizards,
  org.testeditor.dsl.common.ui.workbench
+Import-Package: javax.inject;version="1.0.0"

--- a/common/org.testeditor.dsl.common/META-INF/MANIFEST.MF
+++ b/common/org.testeditor.dsl.common/META-INF/MANIFEST.MF
@@ -19,8 +19,7 @@ Require-Bundle: org.eclipse.xtend.lib.macro,
  org.testeditor.dsl.common.model;bundle-version="1.2.0",
  org.eclipse.jdt.core;bundle-version="3.12.0",
  org.apache.commons.lang3;bundle-version="3.1.0",
- org.gradle.toolingapi;bundle-version="2.14.0",
- javax.inject;bundle-version="1.0.0.v20091030"
+ org.gradle.toolingapi;bundle-version="2.14.0"
 Export-Package: org.testeditor.dsl.common.ide.util,
  org.testeditor.dsl.common.util,
  org.testeditor.dsl.common.util.classpath

--- a/common/org.testeditor.dsl.common/META-INF/MANIFEST.MF
+++ b/common/org.testeditor.dsl.common/META-INF/MANIFEST.MF
@@ -18,12 +18,12 @@ Require-Bundle: org.eclipse.xtend.lib.macro,
  org.eclipse.core.resources;bundle-version="3.11.0",
  org.testeditor.dsl.common.model;bundle-version="1.2.0",
  org.eclipse.jdt.core;bundle-version="3.12.0",
- org.eclipse.m2e.maven.runtime;bundle-version="1.7.0",
- org.eclipse.m2e.core,
  org.apache.commons.lang3;bundle-version="3.1.0",
- org.gradle.toolingapi;bundle-version="2.14.0"
+ org.gradle.toolingapi;bundle-version="2.14.0",
+ javax.inject;bundle-version="1.0.0.v20091030"
 Export-Package: org.testeditor.dsl.common.ide.util,
  org.testeditor.dsl.common.util,
  org.testeditor.dsl.common.util.classpath
+Import-Package: javax.inject;version="1.0.0"
 Eclipse-BundleShape: dir
 Bundle-ActivationPolicy: lazy

--- a/common/org.testeditor.dsl.common/src/org/testeditor/dsl/common/util/MavenExecutor.java
+++ b/common/org.testeditor.dsl.common/src/org/testeditor/dsl/common/util/MavenExecutor.java
@@ -25,7 +25,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.SystemUtils;
-import org.apache.maven.cli.MavenCli;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -48,32 +47,6 @@ public class MavenExecutor {
 
 	public enum MavenVersionValidity {
 		wrong_version, unknown_version, ok, no_maven
-	}
-
-	/**
-	 * Executes the maven build using maven embedder. It allways starts with a
-	 * clean operation to delete old test results.
-	 * 
-	 * @param parameters
-	 *            for maven (separated by spaces, e.g. "clean integration-test"
-	 *            to execute the given goals)
-	 * @param pathToPom
-	 *            path to the folder where the pom.xml is located.
-	 * @return int with exit code
-	 * 
-	 */
-	public int execute(String parameters, String pathToPom) {
-		System.setProperty("maven.multiModuleProjectDirectory", pathToPom);
-		MavenCli cli = new MavenCli();
-		List<String> params = new ArrayList<String>();
-		params.addAll(Arrays.asList(parameters.split(" ")));
-		String mavenSettings = System.getProperty("TE.MAVENSETTINGSPATH");
-		if (mavenSettings != null && mavenSettings.length() > 0) {
-			params.add("-s");
-			params.add(mavenSettings);
-		}
-		int result = cli.doMain(params.toArray(new String[] {}), pathToPom, System.out, System.err);
-		return result;
 	}
 
 	/**
@@ -155,31 +128,6 @@ public class MavenExecutor {
 			return mavenHome + "\\bin\\mvn.bat";
 		} else {
 			return mavenHome + "/bin/mvn";
-		}
-	}
-
-	/**
-	 * Entry point of the new jvm used for the maven build.
-	 * 
-	 * @param args
-	 *            the maven parameter.
-	 */
-	public static void main(String[] args) {
-		logger.info("Proxy host: {}", System.getProperty("http.proxyHost"));
-		if (args.length > 2) {
-			if (args[2].contains("=")) {
-				logger.info("Running maven build with settings='{}'", args[2]);
-				String[] split = args[2].split("=");
-				System.setProperty(split[0], split[1]);
-			} else {
-				logger.warn("Running maven build IGNORING MISSPELLED settings='{}' (missing infix '=')", args[2]);
-			}
-		} else {
-			logger.info("Running maven build without settings");
-		}
-		int result = new MavenExecutor().execute(args[0], args[1]);
-		if (result != 0) {
-			System.exit(result);
 		}
 	}
 

--- a/common/org.testeditor.logging.tests/META-INF/MANIFEST.MF
+++ b/common/org.testeditor.logging.tests/META-INF/MANIFEST.MF
@@ -12,5 +12,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.testeditor.dsl.common.testing,
  org.eclipse.xtext.junit4,
  org.junit;bundle-version="4.12.0"
+Import-Package: javax.inject;version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .

--- a/docs/injection.md
+++ b/docs/injection.md
@@ -1,0 +1,27 @@
+# Injection
+
+
+## OSGI background information
+
+* METAINF.MF
+** Require-Bundle
+
+- specifies the explicit bundle (and optionally version) to use. If a required bundle needs to be refactored and a package moved elsewhere, then dependents will need changes to their MANIFEST.MF
+- gives you accesss to ALL exports of the bundle, regardless of what they are, and regardless of whether you need them. If the parts you don't need have their own dependencies you will need those to
+- bundles can be re-exported
+- although discouraged, allows the use of split packages, ie: a package that is spread across multiple bundles
+- can be used for non-code dependencies, eg: resources, Help etc.
+
+** Import-Package (preferred)
+
+- looser coupling, only the package (and optionally version) is specified and the run-time finds the required bundle
+- actual implementations can be swaped out
+- dependent packages can be moved to different bundles by the package owner
+- requires more metadata to be maintained (i.e: each package name) at lower levels of granularity
+
+[see stackoverflow](http://stackoverflow.com/questions/1865819/when-should-i-use-import-package-and-when-should-i-use-require-bundle)
+
+## E4 Injection
+
+
+## Xtext Guice Injection

--- a/legacy/org.testeditor.aml.legacy.importer.ui/META-INF/MANIFEST.MF
+++ b/legacy/org.testeditor.aml.legacy.importer.ui/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Require-Bundle: org.eclipse.ui,
  org.testeditor.aml.dsl.ui,
  org.testeditor.aml.model,
  org.testeditor.aml.legacy.model
+Import-Package: javax.inject;version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Signal Iduna Corporation

--- a/rcp/org.testeditor.rcp4.tcltestrun.tests/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.tcltestrun.tests/META-INF/MANIFEST.MF
@@ -5,5 +5,6 @@ Bundle-SymbolicName: org.testeditor.rcp4.tcltestrun.tests
 Bundle-Version: 1.6.0.qualifier
 Fragment-Host: org.testeditor.rcp4.tcltestrun;bundle-version="1.0.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Import-Package: javax.inject;version="1.0.0"
 Require-Bundle: org.junit;bundle-version="4.12.0",
  org.testeditor.dsl.common.testing;bundle-version="1.0.1"

--- a/rcp/org.testeditor.rcp4.tcltestrun/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.tcltestrun/META-INF/MANIFEST.MF
@@ -9,11 +9,10 @@ Require-Bundle: org.eclipse.xtend.lib,
  org.gradle.toolingapi,
  org.testeditor.logging,
  org.testeditor.dsl.common.ui;bundle-version="1.0.0",
- org.eclipse.m2e.maven.runtime;bundle-version="1.6.2",
- org.eclipse.m2e.core;bundle-version="1.6.2",
  org.eclipse.e4.core.contexts;bundle-version="1.4.0",
-  org.eclipse.e4.core.di,
+ org.eclipse.e4.core.di,
  org.testeditor.tcl.dsl.ui;bundle-version="1.0.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.testeditor.rcp4.tcltestrun
+Import-Package: javax.inject;version="1.0.0"
 Bundle-ActivationPolicy: lazy

--- a/rcp/org.testeditor.rcp4.tests/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.tests/META-INF/MANIFEST.MF
@@ -8,4 +8,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.testeditor.dsl.common.testing;bundle-version="1.0.0",
  org.junit
 Import-Package: org.eclipse.swt.widgets,
- org.eclipse.ui
+ org.eclipse.ui,
+ javax.inject;version="1.0.0"

--- a/rcp/org.testeditor.rcp4.views.projectexplorer.tests/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.views.projectexplorer.tests/META-INF/MANIFEST.MF
@@ -7,3 +7,4 @@ Fragment-Host: org.testeditor.rcp4.views.projectexplorer;bundle-version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0",
  org.testeditor.dsl.common.testing;bundle-version="1.2.0"
+Import-Package: javax.inject;version="1.0.0"

--- a/rcp/org.testeditor.rcp4.views.projectexplorer/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.views.projectexplorer/META-INF/MANIFEST.MF
@@ -18,4 +18,5 @@ Require-Bundle: org.eclipse.ui.navigator;bundle-version="3.6.0",
  org.testeditor.dsl.common,
  org.testeditor.dsl.common.ui,
  org.testeditor.logging
+Import-Package: javax.inject;version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/rcp/org.testeditor.rcp4.views.tcltestrun.tests/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.views.tcltestrun.tests/META-INF/MANIFEST.MF
@@ -8,3 +8,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.12.0",
  org.testeditor.dsl.common.testing;bundle-version="1.0.1",
  org.eclipse.e4.core.di;bundle-version="1.6.0"
+Import-Package: javax.inject;version="1.0.0"

--- a/rcp/org.testeditor.rcp4.views.tcltestrun/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.views.tcltestrun/META-INF/MANIFEST.MF
@@ -29,6 +29,7 @@ Import-Package: javax.servlet,
  javax.servlet.http,
  org.eclipse.equinox.http.servlet;version="1.2.0",
  org.osgi.service.http;version="1.2.1",
- org.osgi.service.http.context;version="1.0.0"
+ org.osgi.service.http.context;version="1.0.0",
+ javax.inject;version="1.0.0"
 Bundle-ClassPath: .
 Eclipse-BundleShape: dir

--- a/rcp/org.testeditor.rcp4.views.teststepselection.tests/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.views.teststepselection.tests/META-INF/MANIFEST.MF
@@ -19,7 +19,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xtext.junit4,
  org.eclipse.jface,
  org.testeditor.rcp4.views.teststepselector
-Import-Package: com.google.inject,
+Import-Package: javax.inject;version="1.0.0",
  org.apache.log4j,
  org.eclipse.xtext.diagnostics,
  org.eclipse.xtext.util,

--- a/rcp/org.testeditor.rcp4.views.teststepselection/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.views.teststepselection/META-INF/MANIFEST.MF
@@ -35,7 +35,8 @@ Require-Bundle: com.google.guava,
  org.eclipse.ui.workbench,
  org.eclipse.xtext.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.e4.core.di,
+Import-Package: javax.inject;version="1.0.0",
+ org.eclipse.e4.core.di,
  org.eclipse.e4.core.di.annotations,
  org.eclipse.e4.core.di.extensions,
  org.eclipse.e4.core.di.internal.extensions,

--- a/rcp/org.testeditor.rcp4.views.testview/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4.views.testview/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.xtend.lib.macro,
  org.eclipse.e4.core.services
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.e4.core.di.annotations,
+Import-Package: javax.inject;version="1.0.0",
+ org.eclipse.e4.core.di.annotations,
  org.eclipse.e4.core.di.extensions,
  org.eclipse.e4.ui.workbench,
  org.eclipse.e4.ui.workbench.modeling,

--- a/rcp/org.testeditor.rcp4/META-INF/MANIFEST.MF
+++ b/rcp/org.testeditor.rcp4/META-INF/MANIFEST.MF
@@ -50,5 +50,6 @@ Import-Package: org.eclipse.core.resources,
  org.eclipse.ui.internal.ide,
  org.eclipse.ui.wizards.newresource,
  org.eclipse.xtext.ui,
- org.osgi.service.event
+ org.osgi.service.event,
+ javax.inject;version="1.0.0"
 Bundle-ActivationPolicy: lazy

--- a/tcl/org.testeditor.tcl.dsl.ide/META-INF/MANIFEST.MF
+++ b/tcl/org.testeditor.tcl.dsl.ide/META-INF/MANIFEST.MF
@@ -3,6 +3,8 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.testeditor.tcl.dsl.ide
 Bundle-Version: 1.6.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Import-Package: javax.inject;version="1.0.0",
+ org.testeditor.tcl.dsl.services
 Export-Package: org.testeditor.tcl.dsl.ide.contentassist.antlr,
  org.testeditor.tcl.dsl.ide.contentassist.antlr.internal,
  org.testeditor.tcl.dsl.ide.highlighting

--- a/tcl/org.testeditor.tcl.dsl.tests/META-INF/MANIFEST.MF
+++ b/tcl/org.testeditor.tcl.dsl.tests/META-INF/MANIFEST.MF
@@ -18,7 +18,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.jdt.core,
  org.eclipse.xtext.builder.standalone,
  org.testeditor.logging;bundle-version="1.2.0"
-Import-Package: javax.inject,
+Import-Package: javax.inject;version="1.0.0",
  org.junit,
  org.junit.runner
 Export-Package: org.testeditor.tcl.dsl.tests,

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/parser/TestConfigurationParserTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/parser/TestConfigurationParserTest.xtend
@@ -1,6 +1,6 @@
 package org.testeditor.tcl.dsl.tests.parser
 
-import com.google.inject.Inject
+import javax.inject.Inject
 import org.junit.Test
 import org.testeditor.tcl.dsl.tests.AbstractTclTest
 import org.testeditor.dsl.common.testing.DslParseHelper

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/util/ValueSpaceHelperTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/util/ValueSpaceHelperTest.xtend
@@ -1,6 +1,6 @@
 package org.testeditor.tcl.util
 
-import com.google.inject.Inject
+import javax.inject.Inject
 import org.eclipse.xtext.resource.XtextResourceSet
 import org.junit.Before
 import org.junit.Test

--- a/tcl/org.testeditor.tcl.dsl.ui.tests/META-INF/MANIFEST.MF
+++ b/tcl/org.testeditor.tcl.dsl.ui.tests/META-INF/MANIFEST.MF
@@ -12,4 +12,4 @@ Require-Bundle: org.junit,
  org.testeditor.aml.dsl,
  org.testeditor.tcl.dsl.tests
 Bundle-Vendor: Signal Iduna Corporation
-
+Import-Package: javax.inject;version="1.0.0"

--- a/tcl/org.testeditor.tcl.dsl.ui/META-INF/MANIFEST.MF
+++ b/tcl/org.testeditor.tcl.dsl.ui/META-INF/MANIFEST.MF
@@ -28,7 +28,8 @@ Require-Bundle: org.testeditor.dsl.common,
  org.eclipse.jdt.debug.ui,
  org.testeditor.logging,
  org.eclipse.e4.core.di.annotations;bundle-version="1.5.0"
-Import-Package: org.apache.log4j
+Import-Package: javax.inject;version="1.0.0",
+ org.apache.log4j
 Export-Package: org.testeditor.tcl.dsl.ui,
  org.testeditor.tcl.dsl.ui.contentassist,
  org.testeditor.tcl.dsl.ui.internal,

--- a/tcl/org.testeditor.tcl.dsl.ui/src/org/testeditor/tcl/dsl/ui/editor/TclModelDragAndDropUpdater.xtend
+++ b/tcl/org.testeditor.tcl.dsl.ui/src/org/testeditor/tcl/dsl/ui/editor/TclModelDragAndDropUpdater.xtend
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.testeditor.tcl.dsl.ui.editor
 
-import com.google.inject.Inject
 import java.util.List
 import java.util.concurrent.atomic.AtomicReference
+import javax.inject.Inject
 import org.eclipse.emf.common.notify.Notification
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.InternalEObject

--- a/tcl/org.testeditor.tcl.dsl.ui/src/org/testeditor/tcl/dsl/ui/labeling/TclLabelProvider.xtend
+++ b/tcl/org.testeditor.tcl.dsl.ui/src/org/testeditor/tcl/dsl/ui/labeling/TclLabelProvider.xtend
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.testeditor.tcl.dsl.ui.labeling
 
-import com.google.inject.Inject
+import javax.inject.Inject
 import org.eclipse.emf.edit.ui.provider.AdapterFactoryLabelProvider
 import org.eclipse.xtext.xbase.ui.labeling.XbaseLabelProvider
 import org.testeditor.tcl.TestStep

--- a/tcl/org.testeditor.tcl.dsl/META-INF/MANIFEST.MF
+++ b/tcl/org.testeditor.tcl.dsl/META-INF/MANIFEST.MF
@@ -22,7 +22,7 @@ Require-Bundle: org.eclipse.xtext,
  org.testeditor.aml.dsl,
  org.eclipse.xtext.builder,
  org.testeditor.logging;bundle-version="1.2.0"
-Import-Package: javax.inject,
+Import-Package: javax.inject;version="1.0.0",
  org.apache.commons.lang3,
  org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
@@ -12,10 +12,10 @@
  *******************************************************************************/
 package org.testeditor.tcl.dsl.jvmmodel
 
-import com.google.inject.Inject
 import java.util.List
 import java.util.Optional
 import java.util.Set
+import javax.inject.Inject
 import org.apache.commons.lang3.StringEscapeUtils
 import org.eclipse.xtext.EcoreUtil2
 import org.eclipse.xtext.common.types.JvmConstructor

--- a/tcl/org.testeditor.tcl.model/META-INF/MANIFEST.MF
+++ b/tcl/org.testeditor.tcl.model/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-ClassPath: .
 Bundle-Vendor: Signal Iduna Corporation
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Import-Package: javax.inject;version="1.0.0"
 Export-Package: org.testeditor.tcl,
  org.testeditor.tcl.impl,
  org.testeditor.tcl.util

--- a/tsl/org.testeditor.tsl.dsl.ide/META-INF/MANIFEST.MF
+++ b/tsl/org.testeditor.tsl.dsl.ide/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.testeditor.tsl.dsl,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.ide
+Import-Package: javax.inject;version="1.0.0"
 Export-Package: org.testeditor.tsl.dsl.ide.contentassist.antlr,
  org.testeditor.tsl.dsl.ide.contentassist.antlr.internal
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tsl/org.testeditor.tsl.dsl.tests/META-INF/MANIFEST.MF
+++ b/tsl/org.testeditor.tsl.dsl.tests/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Require-Bundle: org.eclipse.xtext,
  org.testeditor.tsl.dsl,
  org.eclipse.xtext.junit4,
  org.testeditor.dsl.common.testing
-Import-Package: org.apache.log4j,
+Import-Package: javax.inject;version="1.0.0",
+ org.apache.log4j,
  org.junit,
  org.junit.runner,
  org.hamcrest.core

--- a/tsl/org.testeditor.tsl.dsl.ui/META-INF/MANIFEST.MF
+++ b/tsl/org.testeditor.tsl.dsl.ui/META-INF/MANIFEST.MF
@@ -19,7 +19,8 @@ Require-Bundle: org.testeditor.dsl.common,
  org.eclipse.ui.editors,
  org.eclipse.xtend.lib;resolution:=optional,
  org.eclipse.xtext.xbase.lib
-Import-Package: org.apache.log4j
+Import-Package: javax.inject;version="1.0.0",
+ org.apache.log4j
 Export-Package: org.testeditor.tsl.dsl.ui,
  org.testeditor.tsl.dsl.ui.contentassist,
  org.testeditor.tsl.dsl.ui.internal,

--- a/tsl/org.testeditor.tsl.dsl.ui/src/org/testeditor/tsl/dsl/ui/labeling/TslLabelProvider.xtend
+++ b/tsl/org.testeditor.tsl.dsl.ui/src/org/testeditor/tsl/dsl/ui/labeling/TslLabelProvider.xtend
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.testeditor.tsl.dsl.ui.labeling
 
-import com.google.inject.Inject
+import javax.inject.Inject
 
 class TslLabelProvider extends org.eclipse.xtext.ui.label.DefaultEObjectLabelProvider {
 

--- a/tsl/org.testeditor.tsl.dsl/META-INF/MANIFEST.MF
+++ b/tsl/org.testeditor.tsl.dsl/META-INF/MANIFEST.MF
@@ -10,8 +10,8 @@ Require-Bundle: org.testeditor.tsl.model;visibility:=reexport,
  org.eclipse.xtext.util,
  org.eclipse.xtend.lib,
  org.eclipse.xtext
-Import-Package: org.apache.log4j,
- javax.inject
+Import-Package: javax.inject;version="1.0.0",
+ org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.testeditor.tsl.dsl,
  org.testeditor.tsl.dsl.formatting2,


### PR DESCRIPTION
reduced m2e dependencies
now javax.inject is used throughout the project
version of javax.inject is pinned to 1.0.0 in all bundles that make use of injection