### PR TITLE
TE-489 adjust eclipse build path for example projects due to gradle upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,15 @@ rcp/org.testeditor.rcp4.uatests/**/org.testeditor.*.png
 ### Test Editor log file ###
 testeditor.log
 
+### Test Editor logs written during test runs ###
+common/org.testeditor.dsl.common.tests/logs/
+common/org.testeditor.dsl.common.ui.tests/logs/
+common/org.testeditor.logging.tests/logs/
+rcp/org.testeditor.rcp4.tests/logs/
+rcp/org.testeditor.rcp4.uatests/logs/
+rcp/org.testeditor.rcp4.views.tcltestrun.tests/logs/
+tcl/org.testeditor.tcl.dsl.tests/logs/
+
 ### NPM ###
 node_modules
 

--- a/common/org.testeditor.dsl.common.ui/src/org/testeditor/dsl/common/ui/utils/ProjectContentGenerator.xtend
+++ b/common/org.testeditor.dsl.common.ui/src/org/testeditor/dsl/common/ui/utils/ProjectContentGenerator.xtend
@@ -186,9 +186,9 @@ class ProjectContentGenerator {
 			RESOURCES_FOLDER,
 			SRC_TEST_FOLDER,
 			RESOURCES_TEST_FOLDER,
-			"build/tcl", // generated test cases
-			"build/tclConfig", // generated test configurations
-			"build/tclMacro" // generated test macros
+			"build/tcl/test", // generated test cases
+			"build/tclConfig/test", // generated test configurations
+			"build/tclMacro/test" // generated test macros
 		]
 		project.setupSourceClassPaths(wantedSourceClassPaths)
 	}


### PR DESCRIPTION
* gitignore logs produced during test runs
* adjust eclipse build path when creating example projects