### PR TITLE
Revert FixtureReference refactoring

### DIFF
--- a/tcl/org.testeditor.tcl.dsl.ide/src/org/testeditor/tcl/dsl/ide/highlighting/TclSemanticHighlightingCalculator.xtend
+++ b/tcl/org.testeditor.tcl.dsl.ide/src/org/testeditor/tcl/dsl/ide/highlighting/TclSemanticHighlightingCalculator.xtend
@@ -23,7 +23,6 @@ import org.testeditor.tcl.TclModel
 import org.testeditor.tcl.TestCase
 import org.testeditor.tcl.TestStep
 import org.testeditor.tcl.TestStepContext
-import org.testeditor.tcl.util.TclModelUtil
 import org.testeditor.tsl.StepContent
 
 import static org.testeditor.dsl.common.CommonPackage.Literals.*
@@ -38,7 +37,6 @@ class TclSemanticHighlightingCalculator extends DefaultSemanticHighlightingCalcu
 	public static val String COMPONENT_ELEMENT_REFERENCE = "tcl.componentElementReference"
 
 	@Inject extension NodeRegionUtil
-	@Inject extension TclModelUtil
 
 	override protected doProvideHighlightingFor(XtextResource resource, IHighlightedPositionAcceptor acceptor,
 		CancelIndicator cancelIndicator) {

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/TclModelGenerator.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/TclModelGenerator.xtend
@@ -170,20 +170,14 @@ class TclModelGenerator {
 	}
 
 	def <T extends TestStep> T withElement(T me, String elementName) {
-		if (me.fixtureReference === null) {
-			me.fixtureReference = tclFactory.createFixtureReference	
-		}
-		me.fixtureReference.contents += tclFactory.createStepContentElement => [
+		me.contents += tclFactory.createStepContentElement => [
 			value = elementName
 		]
 		return me
 	}
 
 	def TestStep withReferenceToTemplateVariable(TestStep me, String variableReferenceName) {
-		if (me.fixtureReference === null) {
-			me.fixtureReference = tclFactory.createFixtureReference	
-		}
-		me.fixtureReference.contents += tclFactory.createVariableReference => [
+		me.contents += tclFactory.createVariableReference => [
 			variable = amlFactory.createTemplateVariable => [
 				name = variableReferenceName
 			]
@@ -192,37 +186,25 @@ class TclModelGenerator {
 	}
 
 	def TestStep withReferenceToVariable(TestStep me, Variable variable) {
-		if (me.fixtureReference === null) {
-			me.fixtureReference = tclFactory.createFixtureReference	
-		}
-		me.fixtureReference.contents += tclFactory.createVariableReference => [
+		me.contents += tclFactory.createVariableReference => [
 			it.variable = variable
 		]
 		return me
 	}
 
 	def TestStep withReference(TestStep me, VariableReference variableReference) {
-		if (me.fixtureReference === null) {
-			me.fixtureReference = tclFactory.createFixtureReference	
-		}
-		me.fixtureReference.contents += variableReference
+		me.contents += variableReference
 		return me
 	}
 
 	def TestStep withParameter(TestStep me, String parameter) {
-		if (me.fixtureReference === null) {
-			me.fixtureReference = tclFactory.createFixtureReference	
-		}
-		me.fixtureReference.contents += tslFactory.createStepContentVariable => [value = parameter]
+		me.contents += tslFactory.createStepContentVariable => [value = parameter]
 		return me
 	}
 
 	def TestStep withText(TestStep me, String ... texts) {
-		if (me.fixtureReference === null) {
-			me.fixtureReference = tclFactory.createFixtureReference	
-		}
 		return me => [
-			texts.forEach[text|fixtureReference.contents += tslFactory.createStepContentText => [value = text]]
+			texts.forEach[text|contents += tslFactory.createStepContentText => [value = text]]
 		]
 	}
 

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/parser/TclModelParserTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/tests/parser/TclModelParserTest.xtend
@@ -134,10 +134,10 @@ class TclModelParserTest extends AbstractTclTest {
 				componentNode.text.trim.assertEquals('GreetingsApplication')
 				steps.assertSize(2)
 				steps.get(0).assertInstanceOf(TestStep) => [
-					fixtureReference.contents.restoreString.assertEquals('starte Anwendung "org.testeditor.swing.exammple.Greetings"')	
+					contents.restoreString.assertEquals('starte Anwendung "org.testeditor.swing.exammple.Greetings"')	
 				]
 				steps.get(1).assertInstanceOf(TestStep) => [
-					fixtureReference.contents.restoreString.assertEquals('gebe in <Eingabefeld> den Wert "Hello World" ein')
+					contents.restoreString.assertEquals('gebe in <Eingabefeld> den Wert "Hello World" ein')
 				]
 			]
 		]
@@ -152,7 +152,7 @@ class TclModelParserTest extends AbstractTclTest {
 			# Test
 			* Dummy step
 				Mask: Demo
-				- some <> < 	> <
+				- <> < 	> <
 				>
 		'''
 		
@@ -161,8 +161,8 @@ class TclModelParserTest extends AbstractTclTest {
 		
 		// then
 		test.steps.assertSingleElement.contexts.assertSingleElement.assertInstanceOf(ComponentTestStepContext) => [
-			val emptyReferences = steps.assertSingleElement.assertInstanceOf(TestStep).fixtureReference.contents.assertSize(4)
-			emptyReferences.drop(1).forEach[
+			val emptyReferences = steps.assertSingleElement.assertInstanceOf(TestStep).contents.assertSize(3)
+			emptyReferences.forEach[
 				assertInstanceOf(StepContentElement) => [
 					value.assertNull
 				]
@@ -190,7 +190,7 @@ class TclModelParserTest extends AbstractTclTest {
 		test.steps.assertSingleElement => [
 			contexts.assertSingleElement.assertInstanceOf(ComponentTestStepContext) => [
 				steps.assertSingleElement.assertInstanceOf(TestStep) => [
-					fixtureReference.contents.restoreString.assertEquals('Is Component visible?')
+					contents.restoreString.assertEquals('Is Component visible?')
 				]
 			]
 		]
@@ -216,7 +216,7 @@ class TclModelParserTest extends AbstractTclTest {
 			contexts.assertSingleElement.assertInstanceOf(ComponentTestStepContext) => [
 				steps.assertSingleElement.assertInstanceOf(TestStepWithAssignment) => [
 					variable.name.assertEquals('hello')
-					fixtureReference.contents.restoreString.assertEquals('Lese den Text von <Input>')
+					contents.restoreString.assertEquals('Lese den Text von <Input>')
 				]
 			]
 		]
@@ -305,10 +305,10 @@ class TclModelParserTest extends AbstractTclTest {
 			contexts.assertSingleElement.assertInstanceOf(MacroTestStepContext) => [
 				steps.assertSize(2)
 				steps.head.assertInstanceOf(TestStep) => [
-					fixtureReference.contents.restoreString.assertMatches('template execute with "param" as a and "param2"')
+					contents.restoreString.assertMatches('template execute with "param" as a and "param2"')
 				]
 				steps.last.assertInstanceOf(TestStep) => [
-					fixtureReference.contents.restoreString.assertMatches('second template')
+					contents.restoreString.assertMatches('second template')
 				]
 			]
 		]

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/validation/TclParameterUsageValidatorTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/validation/TclParameterUsageValidatorTest.xtend
@@ -208,7 +208,7 @@ class TclParameterUsageValidatorTest extends AbstractParserTestWithDummyComponen
 		tclModel.addToResourceSet('test.tcl')
 		
 		// when then
-		validator.assertError(tclModel, FIXTURE_REFERENCE, TclValidator.INVALID_VAR_DEREF) // since assignment must take place before usage!
+		validator.assertError(tclModel, TEST_STEP, TclValidator.INVALID_VAR_DEREF) // since assignment must take place before usage!
 	}
 	
 	@Test
@@ -226,7 +226,7 @@ class TclParameterUsageValidatorTest extends AbstractParserTestWithDummyComponen
 		tclModel.addToResourceSet('MyTest.tcl')
 		
 		// when then
-		validator.assertError(tclModel, FIXTURE_REFERENCE, TclValidator.INVALID_PARAMETER_TYPE)
+		validator.assertError(tclModel, TEST_STEP, TclValidator.INVALID_PARAMETER_TYPE)
 	}
 	
 	@Test
@@ -265,7 +265,7 @@ class TclParameterUsageValidatorTest extends AbstractParserTestWithDummyComponen
 		tclModel.addToResourceSet('MyTest.tcl')
 		
 		// when then
-		validator.assertError(tclModel, FIXTURE_REFERENCE, TclValidator.INVALID_TYPED_VAR_DEREF) // since long is expected, and map is provided
+		validator.assertError(tclModel, TEST_STEP, TclValidator.INVALID_TYPED_VAR_DEREF) // since long is expected, and map is provided
 	}
 	
 	@Test

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/validation/TclVarUsageValidatorTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/validation/TclVarUsageValidatorTest.xtend
@@ -68,7 +68,7 @@ class TclVarUsageValidatorTest extends AbstractParserTestWithDummyComponent {
 						steps += assignmentStep
 						steps += testStep("start") => [
 							// variable map access is valid: declared first, usage within same test case, type of variable is Map
-							fixtureReference.contents += mappedReference(assignmentStep.variable)
+							contents += mappedReference(assignmentStep.variable)
 						]
 					]
 				]
@@ -177,7 +177,7 @@ class TclVarUsageValidatorTest extends AbstractParserTestWithDummyComponent {
 		tclModel.addToResourceSet('Test.tml')
 
 		// then
-		tclModel.assertError(FIXTURE_REFERENCE, TclValidator.INVALID_VAR_DEREF)
+		tclModel.assertError(TEST_STEP, TclValidator.INVALID_VAR_DEREF)
 
 	}
 
@@ -237,7 +237,7 @@ class TclVarUsageValidatorTest extends AbstractParserTestWithDummyComponent {
 						steps += assignmentStep
 						steps += testStep("start") => [
 							// map access is illegal, since variable is of type String
-							fixtureReference.contents += mappedReference(assignmentStep.variable) => [ key = "some" ]
+							contents += mappedReference(assignmentStep.variable) => [ key = "some" ]
 						]
 					]
 				]
@@ -246,7 +246,7 @@ class TclVarUsageValidatorTest extends AbstractParserTestWithDummyComponent {
 		tclModel.addToResourceSet('Test.tcl')
 		
 		// then
-		tclModel.assertError(FIXTURE_REFERENCE, TclValidator.INVALID_MAP_ACCESS)
+		tclModel.assertError(TEST_STEP, TclValidator.INVALID_MAP_ACCESS)
 	}
 
 	@Test

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/util/TclModelUtilTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/util/TclModelUtilTest.xtend
@@ -36,14 +36,14 @@ class TclModelUtilTest extends AbstractParserTest {
 	@Test
 	def void testRestoreString() {
 		// given
-		val testStep = parse('-  some <hello>     world "ohoh"   @xyz', grammarAccess.testStepRule, TestStep)
-		testStep.fixtureReference.contents.get(4).assertInstanceOf(VariableReference)
+		val testStep = parse('-  <hello>     world "ohoh"   @xyz', grammarAccess.testStepRule, TestStep)
+		testStep.contents.get(3).assertInstanceOf(VariableReference)
 
 		// when
-		val result = tclModelUtil.restoreString(testStep.fixtureReference.contents)
+		val result = tclModelUtil.restoreString(testStep.contents)
 
 		// then
-		result.assertMatches('some <hello> world "ohoh" @') // empty variable reference name, since the reference is null
+		result.assertMatches('<hello> world "ohoh" @') // empty variable reference name, since the reference is null
 	}
 
 	@Test
@@ -55,10 +55,10 @@ class TclModelUtilTest extends AbstractParserTest {
 		val dotAndWhitespace = parse('- Hello World.', grammarAccess.testStepRule, TestStep)
 
 		// when, then
-		tclModelUtil.restoreString(questionMark.fixtureReference.contents).assertEquals('Hello World?')
-		tclModelUtil.restoreString(questionMarkAndWhitespace.fixtureReference.contents).assertEquals('Hello World?')
-		tclModelUtil.restoreString(dot.fixtureReference.contents).assertEquals('Hello World.')
-		tclModelUtil.restoreString(dotAndWhitespace.fixtureReference.contents).assertEquals('Hello World.')
+		tclModelUtil.restoreString(questionMark.contents).assertEquals('Hello World?')
+		tclModelUtil.restoreString(questionMarkAndWhitespace.contents).assertEquals('Hello World?')
+		tclModelUtil.restoreString(dot.contents).assertEquals('Hello World.')
+		tclModelUtil.restoreString(dotAndWhitespace.contents).assertEquals('Hello World.')
 	}
 
 	@Test
@@ -127,8 +127,8 @@ class TclModelUtilTest extends AbstractParserTest {
 		val template = parse('''
 			"start with" ${somevar} "and more" ${othervar}
 		''', grammarAccess.templateRule, Template)
-		val someValue = testStep.fixtureReference.contents.filter(StepContentVariable).head
-		val otherRef = testStep.fixtureReference.contents.filter(VariableReference).head
+		val someValue = testStep.contents.filter(StepContentVariable).head
+		val otherRef = testStep.contents.filter(VariableReference).head
 		val somevar = template.contents.get(1)
 		val othervar = template.contents.get(3)
 

--- a/tcl/org.testeditor.tcl.dsl.ui/src/org/testeditor/tcl/dsl/ui/editor/DropUtils.xtend
+++ b/tcl/org.testeditor.tcl.dsl.ui/src/org/testeditor/tcl/dsl/ui/editor/DropUtils.xtend
@@ -71,25 +71,22 @@ class DropUtils {
 
 	public def createDroppedTestStep(InteractionType interactionType, ComponentElement componentElement) {
 		val newTestStep = tclFactory.createTestStep
-		if (newTestStep.fixtureReference === null) {
-			newTestStep.fixtureReference = tclFactory.createFixtureReference
-		}
 		interactionType.template.contents.forEach [
 			switch (it) {
 				TemplateText: {
 					val stepContentText = tslFactory.createStepContentText
 					stepContentText.value = value
-					newTestStep.fixtureReference.contents.add(stepContentText)
+					newTestStep.contents.add(stepContentText)
 				}
 				TemplateVariable: {
 					if (name != 'element') {
 						val stepContentVariable = tslFactory.createStepContentVariable
 						stepContentVariable.value = name
-						newTestStep.fixtureReference.contents.add(stepContentVariable)
+						newTestStep.contents.add(stepContentVariable)
 					} else {
 						val stepContentElement = tclFactory.createStepContentElement
 						stepContentElement.value = componentElement.name
-						newTestStep.fixtureReference.contents.add(stepContentElement)
+						newTestStep.contents.add(stepContentElement)
 					}
 				}
 				default:

--- a/tcl/org.testeditor.tcl.dsl.ui/src/org/testeditor/tcl/dsl/ui/navigation/TclHyperLinkHelper.xtend
+++ b/tcl/org.testeditor.tcl.dsl.ui/src/org/testeditor/tcl/dsl/ui/navigation/TclHyperLinkHelper.xtend
@@ -48,10 +48,10 @@ class TclHyperLinkHelper extends XbaseHyperLinkHelper {
 	protected def dispatch void createHyperlinks(TestStep testStep, IHyperlinkAcceptor acceptor) {
 		val interaction = testStep.interaction
 		if (interaction !== null) {
-			testStep.createHyperlinkTo(FIXTURE_REFERENCE__CONTENTS, interaction.template, acceptor)
+			testStep.createHyperlinkTo(TEST_STEP__CONTENTS, interaction.template, acceptor)
 		} else if (testStep.hasMacroContext) {
 			val macroTemplate = testStep.findMacroDefinition(testStep.macroContext)?.template
-			testStep.createHyperlinkTo(FIXTURE_REFERENCE__CONTENTS, macroTemplate, acceptor)
+			testStep.createHyperlinkTo(TEST_STEP__CONTENTS, macroTemplate, acceptor)
 		}
 	}
 

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/Tcl.xtext
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/Tcl.xtext
@@ -107,20 +107,17 @@ MacroTestStepContext returns TestStepContext:
  */
 TestStep:
 	{TestStep}
-	'-' fixtureReference=FixtureReference?;
+	'-' contents+=StepContent* contents+=StepContentPunctuation?;
 
 AssertionTestStep:
 	'-' 'assert' assertExpression=(NullOrBoolCheck | FullComparison) '.'?;
 
 TestStepWithAssignment:
-	'-' variable=AssignmentVariable '=' fixtureReference=FixtureReference;
+	'-' variable=AssignmentVariable '=' contents+=StepContent* contents+=StepContentPunctuation?;
 
 MapEntryAssignment:
 	'-' variableReference=VariableReferenceMapAccess '=' expression=AtomicValue '.'?;
 
-FixtureReference:
-	contents+=StepContentText contents+=StepContent* contents+=StepContentPunctuation?;
-    
 /** expression order: Comparison -> (Addition -> Multiplication ->) Value
  *  which is reflecting the order of operator binding.
  * 

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/formatting2/TclFormatter.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/formatting2/TclFormatter.xtend
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.testeditor.tcl.dsl.formatting2;
 
-import javax.inject.Inject
 import org.eclipse.xtext.formatting2.IFormattableDocument
 import org.eclipse.xtext.xbase.formatting2.XbaseFormatter
 import org.testeditor.aml.Template
@@ -32,7 +31,6 @@ import org.testeditor.tcl.TestSetup
 import org.testeditor.tcl.TestStep
 import org.testeditor.tcl.VariableReference
 import org.testeditor.tcl.VariableReferenceMapAccess
-import org.testeditor.tcl.util.TclModelUtil
 import org.testeditor.tsl.StepContentText
 import org.testeditor.tsl.StepContentVariable
 import org.testeditor.tsl.TslPackage
@@ -43,8 +41,6 @@ import static org.testeditor.tcl.TclPackage.Literals.*
 
 class TclFormatter extends XbaseFormatter {
 	
-	@Inject extension TclModelUtil 
-
 	def dispatch void format(TclModel tclModel, extension IFormattableDocument document) {
 		tclModel.regionFor.feature(TCL_MODEL__PACKAGE).prepend[oneSpace].append[newLines = 2]
 		// import section is not formatted (yet), should be done by organize imports

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/validation/TclTypeValidationUtil.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/validation/TclTypeValidationUtil.xtend
@@ -40,7 +40,6 @@ class TclTypeValidationUtil {
 	 * get the type that this stepContent is expected to have in order to satisfy the parameter type of its transitively called fixture  
 	 */
 	def Optional<JvmTypeReference> getExpectedType(StepContent stepContent, TemplateContainer templateContainer)  {
-		val step = EcoreUtil2.getContainerOfType(stepContent, TestStep)
 		val parameterTypeMap = simpleTypeComputer.getVariablesWithTypes(templateContainer)
 		val templateParameter = getTemplateParameterForCallingStepContent(stepContent)
 		val expectedType = parameterTypeMap.get(templateParameter)

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/validation/TclValidator.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/validation/TclValidator.xtend
@@ -116,7 +116,7 @@ class TclValidator extends AbstractTclValidator {
 		if (!(testStep instanceof AssertionTestStep) && testStep.hasComponentContext) {
 			val method = testStep.interaction?.defaultMethod
 			if ((method == null ) || (method.operation == null) || (method.typeReference?.type == null)) {
-				info("test step could not resolve fixture", TclPackage.Literals.TEST_STEP__FIXTURE_REFERENCE, MISSING_FIXTURE)
+				info("test step could not resolve fixture", TclPackage.Literals.TEST_STEP__CONTENTS, MISSING_FIXTURE)
 			}
 		}
 	}
@@ -127,7 +127,7 @@ class TclValidator extends AbstractTclValidator {
 			val normalizedTeststep = testStep.normalize
 			val macroCollection = testStep.macroContext.macroCollection
 			if (!macroCollection.macros.exists[template.normalize == normalizedTeststep]) {
-				warning("test step could not resolve macro usage", TclPackage.Literals.TEST_STEP__FIXTURE_REFERENCE,
+				warning("test step could not resolve macro usage", TclPackage.Literals.TEST_STEP__CONTENTS,
 					MISSING_MACRO)
 			}
 		}

--- a/tcl/org.testeditor.tcl.model/model/tcl.xcore
+++ b/tcl/org.testeditor.tcl.model/model/tcl.xcore
@@ -104,11 +104,7 @@ abstract class AbstractTestStep {
 }
 
 class TestStep extends AbstractTestStep {
-	contains FixtureReference fixtureReference
-}
-
-class FixtureReference {
-	contains StepContent[0..*] contents	
+	contains StepContent[0..*] contents
 }
 
 class MapEntryAssignment extends AbstractTestStep {

--- a/tcl/org.testeditor.tcl.model/src/org/testeditor/tcl/util/TclModelUtil.xtend
+++ b/tcl/org.testeditor.tcl.model/src/org/testeditor/tcl/util/TclModelUtil.xtend
@@ -292,15 +292,5 @@ class TclModelUtil extends TslModelUtil {
 			variables.contains(variable.name)
 		]
 	}
-	
-	/**
-	 * allow usage of "contents" on TestStep s even if fixtureReference is null
-	 */
-	def Iterable<StepContent> getContents(TestStep testStep) {
-		if (testStep.fixtureReference !== null) {
-			return testStep.fixtureReference.contents
-		}	
-		return emptyList
-	}
 
 }


### PR DESCRIPTION
The introduction of the class `FixtureReference` made the code more complex without any benefits and also broke the UI navigation from test steps to their AML templates (`TclHyperLinkHelper`).