### PR TITLE
TE-492 fix exception during test selection

### DIFF
--- a/common/org.testeditor.dsl.common/src/org/testeditor/dsl/common/util/classpath/ClasspathUtil.xtend
+++ b/common/org.testeditor.dsl.common/src/org/testeditor/dsl/common/util/classpath/ClasspathUtil.xtend
@@ -19,6 +19,7 @@ import org.eclipse.core.runtime.CoreException
 import org.eclipse.core.runtime.IPath
 import org.eclipse.core.runtime.NullProgressMonitor
 import org.eclipse.core.runtime.Path
+import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.jdt.core.IClasspathEntry
 import org.eclipse.jdt.core.IJavaElement
@@ -44,8 +45,9 @@ class ClasspathUtil {
 
 	// called from rcp or during build (outside of rcp)
 	def String inferPackage(EObject element) {
-		val originPath = new Path(EcoreUtil2.getPlatformResourceOrNormalizedURI(element).trimFragment.path)
-		if (originPath.isEclipseResolved) {
+		val elementURI = EcoreUtil2.getPlatformResourceOrNormalizedURI(element)
+		val originPath = new Path(elementURI.trimFragment.path)
+		if (elementURI.isEclipseResolved) {
 			val adjustedPath = originPath.removeFirstSegments(1).removeLastSegments(1)
 			val classpath = getClasspathEntryFor(adjustedPath, true)
 			return packageForPath(adjustedPath, classpath)
@@ -156,8 +158,8 @@ class ClasspathUtil {
 		}
 	}
 
-	def protected boolean getIsEclipseResolved(IPath path) {
-		return path.toString.startsWith("/resource/")
+	def protected boolean getIsEclipseResolved(URI uri) {
+		return uri.scheme.equals("platform")
 	}
 
 	def IPath getBuildProjectBaseDir(IPath path) {

--- a/common/org.testeditor.dsl.common/src/org/testeditor/dsl/common/util/classpath/ClasspathUtil.xtend
+++ b/common/org.testeditor.dsl.common/src/org/testeditor/dsl/common/util/classpath/ClasspathUtil.xtend
@@ -159,7 +159,7 @@ class ClasspathUtil {
 	}
 
 	def protected boolean getIsEclipseResolved(URI uri) {
-		return uri.scheme.equals("platform")
+		return "platform".equals(uri.scheme)
 	}
 
 	def IPath getBuildProjectBaseDir(IPath path) {

--- a/rcp/org.testeditor.rcp4.views.projectexplorer/plugin.xml
+++ b/rcp/org.testeditor.rcp4.views.projectexplorer/plugin.xml
@@ -232,7 +232,7 @@
 						<adapt type="org.eclipse.core.resources.IFolder">
 							<and>
 								<test forcePluginActivation="true"
-									property="org.testeditor.rcp4.views.projectexplorer.checkFolder" value="nonroot">
+									property="org.testeditor.rcp4.views.projectexplorer.checkFolder">
 								</test>
 							</and>
 						</adapt>

--- a/rcp/org.testeditor.rcp4.views.tcltestrun/src/org/testeditor/rcp4/views/tcltestrun/TclLauncherUi.xtend
+++ b/rcp/org.testeditor.rcp4.views.tcltestrun/src/org/testeditor/rcp4/views/tcltestrun/TclLauncherUi.xtend
@@ -15,7 +15,6 @@ package org.testeditor.rcp4.views.tcltestrun
 import java.io.File
 import java.io.FileOutputStream
 import java.nio.file.Files
-import java.util.ArrayList
 import java.util.List
 import java.util.Map
 import java.util.concurrent.atomic.AtomicReference
@@ -45,6 +44,7 @@ import org.testeditor.dsl.common.ui.utils.WorkbenchHelper
 import org.testeditor.dsl.common.ui.workbench.PartHelper
 import org.testeditor.dsl.common.util.EclipseContextHelper
 import org.testeditor.dsl.common.util.MavenExecutor
+import org.testeditor.dsl.common.util.classpath.ClasspathUtil
 import org.testeditor.rcp4.tcltestrun.LaunchResult
 import org.testeditor.rcp4.tcltestrun.TclGradleLauncher
 import org.testeditor.rcp4.tcltestrun.TclMavenLauncher
@@ -69,17 +69,18 @@ class TclLauncherUi implements Launcher {
 	@Inject TestResultFileWriter testResultFileWriter
 	@Inject TclIndexHelper indexHelper
 	@Inject TclInjectorProvider tclInjectorProvider
-	Map<URI, ArrayList<TestCase>> tslIndex
 	@Inject TCLConsoleFactory consoleFactory
 	@Inject PartHelper partHelper
 	@Inject EclipseContextHelper eclipseContextHelper
 	@Inject TestExecutionManager testExecutionManager
 	@Inject WorkbenchHelper workbenchHelper
+	@Inject ClasspathUtil classpathUtil
+	
+	Map<URI, List<TestCase>> tslIndex
 
 	override boolean launch(IStructuredSelection selection, IProject project, String mode, boolean parameterize) {
 		eclipseContextHelper.eclipseContext.set(TclLauncherUi, this)
 		val options = newHashMap
-		tslIndex = indexHelper.createTestCaseIndex
 		if (project.getFile("build.gradle").exists) {
 			return launchTest(
 				new TestLaunchInformation(createGradleTestCasesList(selection), project, gradleLauncher, options))
@@ -87,7 +88,7 @@ class TclLauncherUi implements Launcher {
 		if (project.getFile("pom.xml").exists && continueWithMaven) {
 			if (parameterize) {
 				val profile = selectMavenProfile(project)
-				if (profile == null) {
+				if (profile === null) {
 					return true // should an option always be selected?
 				}
 				options.put(TclMavenLauncher.PROFILE, profile)
@@ -108,7 +109,7 @@ class TclLauncherUi implements Launcher {
 		val job = new Job("Test execution") {
 
 			override protected run(IProgressMonitor monitor) {
-				if (testLaunchInformation.testCasesCommaList != null) {
+				if (testLaunchInformation.testCasesCommaList !== null) {
 					monitor.beginTask("Test execution: " + testLaunchInformation.testCasesCommaList.head,
 						IProgressMonitor.UNKNOWN)
 				} else {
@@ -129,7 +130,7 @@ class TclLauncherUi implements Launcher {
 					output.close
 				}
 				testLaunchInformation.project.refreshLocal(IProject.DEPTH_INFINITE, monitor)
-				if (result.expectedFileRoot == null) {
+				if (result.expectedFileRoot === null) {
 					logger.error("resulting expectedFile must not be null")
 				} else {
 					safeUpdateJunitTestView(result.expectedFileRoot, testLaunchInformation.project.name)
@@ -157,7 +158,7 @@ class TclLauncherUi implements Launcher {
 		result += selection.toList.filter(IResource).map [ resource |
 			if (resource instanceof IFolder) {
 				val javaElement = resource.getAdapter(IJavaElement)
-				if (javaElement != null) {
+				if (javaElement !== null) {
 					return javaElement.elementName + "*"
 				} else {
 					logger.warn("selected element = {} is not a test exeutuable", resource.name)
@@ -165,8 +166,7 @@ class TclLauncherUi implements Launcher {
 				}
 
 			} else {
-				return tclInjectorProvider.get.getInstance(LaunchShortcutUtil).getQualifiedNameForTestInTcl(resource).
-					toString
+				return resource.testCaseListFromSelection.head
 			}
 		].filterNull
 
@@ -216,13 +216,29 @@ class TclLauncherUi implements Launcher {
 			val uri = URI.createPlatformResourceURI(resource.locationURI.toString, true).deresolve(
 				URI.createPlatformResourceURI(resource.project.locationURI.toString, true))
 			val secondURI = URI.createPlatformResourceURI(uri.toString, true)
+			if (tslIndex === null) {
+				tslIndex = indexHelper.createTestCaseIndex(resource.project)
+			}
 			if (tslIndex.containsKey(secondURI)) {
-				return tslIndex.get(secondURI).map[it.model.package + "." + it.name]
+				return tslIndex.get(secondURI).map[qualifiedNameString]
 			}
 			return emptyList
 		} else {
 			val launchShortcutUtil = tclInjectorProvider.get.getInstance(LaunchShortcutUtil)
 			return #[launchShortcutUtil.getQualifiedNameForTestInTcl(resource).toString]
+		}
+	}
+
+	private def String qualifiedNameString(TestCase testCase) {
+		if (testCase.model.package.nullOrEmpty) {
+			val package = classpathUtil.inferPackage(testCase.model)
+			if (package.empty) {
+				return testCase.name
+			} else {
+				return package + "." + testCase.name
+			}
+		} else {
+			return testCase.model.package + "." + testCase.name
 		}
 	}
 
@@ -248,7 +264,7 @@ class TclLauncherUi implements Launcher {
 		logger.debug("Test result parentPir={}", expectedFileRoot)
 		val xmlResults = expectedFileRoot.listFiles[it.isFile && it.name.endsWith(".xml")]
 		val resultFile = new File(expectedFileRoot, "te-testCompose.xml")
-		if (xmlResults != null && xmlResults.length > 0) {
+		if (xmlResults !== null && xmlResults.length > 0) {
 			testResultFileWriter.writeTestResultFile(projectName, resultFile, xmlResults)
 		} else {
 			testResultFileWriter.writeErrorFile(projectName, resultFile)

--- a/tcl/org.testeditor.tcl.dsl.ui/src/org/testeditor/tcl/dsl/ui/util/TclIndexHelper.xtend
+++ b/tcl/org.testeditor.tcl.dsl.ui/src/org/testeditor/tcl/dsl/ui/util/TclIndexHelper.xtend
@@ -1,33 +1,34 @@
 package org.testeditor.tcl.dsl.ui.util
 
-import java.util.ArrayList
+import java.util.List
 import java.util.Map
 import javax.inject.Inject
+import org.eclipse.core.resources.IProject
 import org.eclipse.emf.common.util.URI
-import org.eclipse.emf.ecore.resource.ResourceSet
+import org.eclipse.jdt.core.JavaCore
 import org.eclipse.xtext.EcoreUtil2
 import org.eclipse.xtext.resource.IResourceDescriptions
+import org.eclipse.xtext.resource.XtextResourceSet
 import org.testeditor.tcl.TclPackage
 import org.testeditor.tcl.TestCase
 
 class TclIndexHelper {
 	
 	@Inject TclInjectorProvider tclInjectorProvider
-	
-	def Map<URI, ArrayList<TestCase>> createTestCaseIndex() {
-		var resourceDescriptions = tclInjectorProvider.get.getInstance(IResourceDescriptions)
-		val rs = tclInjectorProvider.get.getInstance(ResourceSet)
+
+	def Map<URI, List<TestCase>> createTestCaseIndex(IProject project) {
+ 		var resourceDescriptions = tclInjectorProvider.get.getInstance(IResourceDescriptions)
+		val rs = tclInjectorProvider.get.getInstance(XtextResourceSet)
+		rs.classpathURIContext = JavaCore.create(project) // make sure org.junit.Test is on the resolvable classpath (is used by generator, which again is used when resolving the test cases)
 		val testCaseDescriptions = resourceDescriptions.getExportedObjectsByType(TclPackage.Literals.TEST_CASE)
-		// resolve of eobjectOrProxy kicks off generation (which fails with this resource set)
-		// doing this just to get the specifications is quite heavy weight
-		// TODO: find some lightweight alternative
 		val testcases = testCaseDescriptions.map[EcoreUtil2.resolve(EObjectOrProxy,rs)].filter(TestCase)
 		val tslIndex = newHashMap
 		testcases.forEach [
 			if (it.specification != null) {
 				val tslKey = it.specification.eContainer.eResource.URI
 				if (!tslIndex.containsKey(tslKey)) {
-					tslIndex.put(tslKey, newArrayList)
+					val List<TestCase> list = newArrayList
+					tslIndex.put(tslKey, list)
 				}
 				tslIndex.get(tslKey).add(it)
 			}

--- a/tsl/org.testeditor.tsl.dsl.ui/src/org/testeditor/tsl/dsl/ui/wizard/NewTslFileWizard.xtend
+++ b/tsl/org.testeditor.tsl.dsl.ui/src/org/testeditor/tsl/dsl/ui/wizard/NewTslFileWizard.xtend
@@ -35,8 +35,6 @@ class NewTslFileWizard extends NewFileWizard {
 
 	override String contentString(String thePackage, String fileName) {
 		return '''
-			package «thePackage ?: "com.example"»
-			
 			# «fileName.replace(".tsl","").toFirstUpper»
 		'''
 	}


### PR DESCRIPTION
* ClasspathUtil: test on uri scheme to check if element is eclipse resolved
* TclLauncherUITest: documentation and added test and made private create methods actually private
* TclLanucherUI: reduce warnings, included package derivation (which was missing), build tslIndex only if actually using a tsl in the selection, allow tsl execution for gradle projects, too
* TclIndexHelper: changed ArrayList -> List in signature, added classpathUriContext to allow resolving org.junit.Test during resolving (and thereby generating) TestCase eObjects 