### PR TITLE
refactorizations in prepartion enum parameters

### DIFF
--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/TclExpressionBuilderTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/TclExpressionBuilderTest.xtend
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.testeditor.tcl.dsl.jvmmodel
 
+import java.util.Optional
 import javax.inject.Inject
 import org.eclipse.xtext.common.types.JvmTypeReference
 import org.junit.Before
@@ -43,8 +44,8 @@ class TclExpressionBuilderTest extends AbstractTclTest {
 	@Before
 	def void prepareMocks() {
 		when(stringTypeReference.qualifiedName).thenReturn(String.name)
-		when(typeComputer.determineType(any(Expression),any(JvmTypeReference))).thenReturn(stringTypeReference)
-		when(typeComputer.determineType(any(Variable),any(JvmTypeReference))).thenReturn(stringTypeReference)
+		when(typeComputer.determineType(any(Expression),any(Optional))).thenReturn(stringTypeReference)
+		when(typeComputer.determineType(any(Variable),any(Optional))).thenReturn(stringTypeReference)
 		when(typeComputer.coercedTypeOfComparison(any, any)).thenReturn(stringTypeReference)
 		when(tclJsonUtil.jsonPathReadAccessToString(any(KeyPathElement))).thenReturn('''.getJsonObject().get("«someKey»")''')
 		when(tclCoercionComputer.generateCoercion(stringTypeReference, stringTypeReference, '"test"')).

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmTypeReferenceUtilTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmTypeReferenceUtilTest.xtend
@@ -1,7 +1,6 @@
 package org.testeditor.tcl.dsl.jvmmodel
 
 import javax.inject.Inject
-import org.eclipse.emf.ecore.resource.ResourceSet
 import org.eclipse.xtext.xbase.typesystem.conformance.TypeConformanceComputationArgument
 import org.junit.Before
 import org.junit.Ignore
@@ -9,22 +8,22 @@ import org.junit.Test
 
 class TclJvmTypeReferenceUtilTest extends AbstractTclGeneratorIntegrationTest{
 
-	@Inject TclJvmTypeReferenceUtil classUnderTest
+	@Inject TclJvmTypeReferenceUtil typeReferenceUtil // class under test
 	@Inject TclJvmTypeReferenceUtil utilForTypeGenerationComparison
 	
 	val standardTestFlags = new TypeConformanceComputationArgument(false, false, false, false, false, true)
 	
 	@Before 
 	def void initClassUnderTest() {
-		classUnderTest.initWith(null as ResourceSet)
-		utilForTypeGenerationComparison.initWith(null as ResourceSet)
+		typeReferenceUtil.initWith(this.resourceSet)
+		utilForTypeGenerationComparison.initWith(this.resourceSet)
 	}
 	
 	@Test
 	def void testBooleanToBooleanObjectAssignmentWithoutBoxing() {
 		// given + when				
-		val isAssignable = classUnderTest.isAssignableFrom(classUnderTest.booleanObjectJvmTypeReference,
-			classUnderTest.buildFrom(Boolean), standardTestFlags)
+		val isAssignable = typeReferenceUtil.isAssignableFrom(typeReferenceUtil.booleanObjectJvmTypeReference,
+			typeReferenceUtil.buildFrom(Boolean), standardTestFlags)
 
 		// then
 		isAssignable.assertTrue
@@ -33,8 +32,8 @@ class TclJvmTypeReferenceUtilTest extends AbstractTclGeneratorIntegrationTest{
 	@Test
 	def void testPrimitiveToBooleanObjectAssignmentWithoutBoxing() {
 		// given + when		
-		val isAssignable = classUnderTest.isAssignableFrom(classUnderTest.booleanObjectJvmTypeReference,
-			classUnderTest.booleanPrimitiveJvmTypeReference, standardTestFlags)
+		val isAssignable = typeReferenceUtil.isAssignableFrom(typeReferenceUtil.booleanObjectJvmTypeReference,
+			typeReferenceUtil.booleanPrimitiveJvmTypeReference, standardTestFlags)
 
 		// then
 		isAssignable.assertFalse
@@ -43,8 +42,8 @@ class TclJvmTypeReferenceUtilTest extends AbstractTclGeneratorIntegrationTest{
 	@Test
 	def void testJsonElementToBooleanObjectAssignmentWithoutBoxing() {
 		// given + when		
-		val isAssignable = classUnderTest.isAssignableFrom(classUnderTest.booleanObjectJvmTypeReference,
-			classUnderTest.jsonElementJvmTypeReference, standardTestFlags)
+		val isAssignable = typeReferenceUtil.isAssignableFrom(typeReferenceUtil.booleanObjectJvmTypeReference,
+			typeReferenceUtil.jsonElementJvmTypeReference, standardTestFlags)
 
 		// then
 		isAssignable.assertFalse
@@ -54,8 +53,8 @@ class TclJvmTypeReferenceUtilTest extends AbstractTclGeneratorIntegrationTest{
 	@Test
 	def void testPrimitiveToBooleanObjectAssignmentWithBoxing() {
 		// given + when		
-		val isAssignable = classUnderTest.isAssignableFrom(classUnderTest.booleanObjectJvmTypeReference,
-			classUnderTest.booleanPrimitiveJvmTypeReference)
+		val isAssignable = typeReferenceUtil.isAssignableFrom(typeReferenceUtil.booleanObjectJvmTypeReference,
+			typeReferenceUtil.booleanPrimitiveJvmTypeReference)
 
 		// then
 		isAssignable.assertTrue
@@ -64,12 +63,12 @@ class TclJvmTypeReferenceUtilTest extends AbstractTclGeneratorIntegrationTest{
 	@Test
 	def void testTypeEquality() {
 		// given
-		val jsonArray = classUnderTest.jsonArrayJvmTypeReference
+		val jsonArray = typeReferenceUtil.jsonArrayJvmTypeReference
 		val myJsonArray = utilForTypeGenerationComparison.jsonArrayJvmTypeReference
 		assertTrue(jsonArray !== myJsonArray) // be sure to use two different instances!
 		
 		// when
-		val result = classUnderTest.isJsonArray(myJsonArray)
+		val result = typeReferenceUtil.isJsonArray(myJsonArray)
 		
 		// then
 		result.assertTrue
@@ -78,47 +77,47 @@ class TclJvmTypeReferenceUtilTest extends AbstractTclGeneratorIntegrationTest{
 	@Test
 	def void testTypeRecognition() {
 		// given + when + then
-		classUnderTest.isBigDecimal(classUnderTest.bigDecimalJvmTypeReference).assertTrue
-		classUnderTest.isBigDecimal(classUnderTest.longObjectJvmTypeReference).assertFalse
+		typeReferenceUtil.isBigDecimal(typeReferenceUtil.bigDecimalJvmTypeReference).assertTrue
+		typeReferenceUtil.isBigDecimal(typeReferenceUtil.longObjectJvmTypeReference).assertFalse
 		
-		classUnderTest.isLong(classUnderTest.longObjectJvmTypeReference).assertTrue
-		classUnderTest.isLong(classUnderTest.longPrimitiveJvmTypeReference).assertTrue
-		classUnderTest.isLong(classUnderTest.bigDecimalJvmTypeReference).assertFalse
+		typeReferenceUtil.isLong(typeReferenceUtil.longObjectJvmTypeReference).assertTrue
+		typeReferenceUtil.isLong(typeReferenceUtil.longPrimitiveJvmTypeReference).assertTrue
+		typeReferenceUtil.isLong(typeReferenceUtil.bigDecimalJvmTypeReference).assertFalse
 		
-		classUnderTest.isInt(classUnderTest.intObjectJvmTypeReference).assertTrue
-		classUnderTest.isInt(classUnderTest.intPrimitiveJvmTypeReference).assertTrue
-		classUnderTest.isInt(classUnderTest.bigDecimalJvmTypeReference).assertFalse
+		typeReferenceUtil.isInt(typeReferenceUtil.intObjectJvmTypeReference).assertTrue
+		typeReferenceUtil.isInt(typeReferenceUtil.intPrimitiveJvmTypeReference).assertTrue
+		typeReferenceUtil.isInt(typeReferenceUtil.bigDecimalJvmTypeReference).assertFalse
 		
-		classUnderTest.isBoolean(classUnderTest.booleanObjectJvmTypeReference).assertTrue
-		classUnderTest.isBoolean(classUnderTest.booleanPrimitiveJvmTypeReference).assertTrue
-		classUnderTest.isBoolean(classUnderTest.stringJvmTypeReference).assertFalse
+		typeReferenceUtil.isBoolean(typeReferenceUtil.booleanObjectJvmTypeReference).assertTrue
+		typeReferenceUtil.isBoolean(typeReferenceUtil.booleanPrimitiveJvmTypeReference).assertTrue
+		typeReferenceUtil.isBoolean(typeReferenceUtil.stringJvmTypeReference).assertFalse
 		
-		classUnderTest.isString(classUnderTest.stringJvmTypeReference).assertTrue
-		classUnderTest.isString(classUnderTest.booleanObjectJvmTypeReference).assertFalse
+		typeReferenceUtil.isString(typeReferenceUtil.stringJvmTypeReference).assertTrue
+		typeReferenceUtil.isString(typeReferenceUtil.booleanObjectJvmTypeReference).assertFalse
 		
-		classUnderTest.isJson(classUnderTest.jsonArrayJvmTypeReference).assertTrue
-		classUnderTest.isJson(classUnderTest.stringJvmTypeReference).assertFalse
+		typeReferenceUtil.isJson(typeReferenceUtil.jsonArrayJvmTypeReference).assertTrue
+		typeReferenceUtil.isJson(typeReferenceUtil.stringJvmTypeReference).assertFalse
 		
-		classUnderTest.isJsonArray(classUnderTest.jsonArrayJvmTypeReference).assertTrue
-		classUnderTest.isJsonArray(classUnderTest.stringJvmTypeReference).assertFalse
-		classUnderTest.isJsonElement(classUnderTest.jsonElementJvmTypeReference).assertTrue
-		classUnderTest.isJsonElement(classUnderTest.stringJvmTypeReference).assertFalse
-		classUnderTest.isJsonObject(classUnderTest.jsonObjectJvmTypeReference).assertTrue
-		classUnderTest.isJsonObject(classUnderTest.stringJvmTypeReference).assertFalse
-		classUnderTest.isJsonPrimitive(classUnderTest.jsonPrimitiveJvmTypeReference).assertTrue
-		classUnderTest.isJsonPrimitive(classUnderTest.stringJvmTypeReference).assertFalse
+		typeReferenceUtil.isJsonArray(typeReferenceUtil.jsonArrayJvmTypeReference).assertTrue
+		typeReferenceUtil.isJsonArray(typeReferenceUtil.stringJvmTypeReference).assertFalse
+		typeReferenceUtil.isJsonElement(typeReferenceUtil.jsonElementJvmTypeReference).assertTrue
+		typeReferenceUtil.isJsonElement(typeReferenceUtil.stringJvmTypeReference).assertFalse
+		typeReferenceUtil.isJsonObject(typeReferenceUtil.jsonObjectJvmTypeReference).assertTrue
+		typeReferenceUtil.isJsonObject(typeReferenceUtil.stringJvmTypeReference).assertFalse
+		typeReferenceUtil.isJsonPrimitive(typeReferenceUtil.jsonPrimitiveJvmTypeReference).assertTrue
+		typeReferenceUtil.isJsonPrimitive(typeReferenceUtil.stringJvmTypeReference).assertFalse
 		
-		classUnderTest.isANumber(classUnderTest.intObjectJvmTypeReference).assertTrue
-		classUnderTest.isANumber(classUnderTest.longObjectJvmTypeReference).assertTrue
-		classUnderTest.isANumber(classUnderTest.bigDecimalJvmTypeReference).assertTrue
+		typeReferenceUtil.isANumber(typeReferenceUtil.intObjectJvmTypeReference).assertTrue
+		typeReferenceUtil.isANumber(typeReferenceUtil.longObjectJvmTypeReference).assertTrue
+		typeReferenceUtil.isANumber(typeReferenceUtil.bigDecimalJvmTypeReference).assertTrue
 		
-		classUnderTest.isNumber(classUnderTest.numberJvmTypeReference).assertTrue
-		classUnderTest.isNumber(classUnderTest.bigDecimalJvmTypeReference).assertFalse
+		typeReferenceUtil.isNumber(typeReferenceUtil.numberJvmTypeReference).assertTrue
+		typeReferenceUtil.isNumber(typeReferenceUtil.bigDecimalJvmTypeReference).assertFalse
 
-		classUnderTest.isOrderable(classUnderTest.bigDecimalJvmTypeReference).assertTrue
-		classUnderTest.isOrderable(classUnderTest.intPrimitiveJvmTypeReference).assertTrue
-		classUnderTest.isOrderable(classUnderTest.longPrimitiveJvmTypeReference).assertTrue
-		classUnderTest.isOrderable(classUnderTest.stringJvmTypeReference).assertFalse // strings are currently not orderable (<, <=, >, >=)
+		typeReferenceUtil.isOrderable(typeReferenceUtil.bigDecimalJvmTypeReference).assertTrue
+		typeReferenceUtil.isOrderable(typeReferenceUtil.intPrimitiveJvmTypeReference).assertTrue
+		typeReferenceUtil.isOrderable(typeReferenceUtil.longPrimitiveJvmTypeReference).assertTrue
+		typeReferenceUtil.isOrderable(typeReferenceUtil.stringJvmTypeReference).assertFalse // strings are currently not orderable (<, <=, >, >=)
 	}
 	
 }

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/TypeExpressionComputerTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/TypeExpressionComputerTest.xtend
@@ -22,6 +22,7 @@ import org.testeditor.tcl.dsl.tests.AbstractTclTest
 import org.testeditor.tsl.impl.TslFactoryImpl
 
 import static org.mockito.Mockito.*
+import java.util.Optional
 
 class TypeExpressionComputerTest extends AbstractTclTest{
 	
@@ -50,7 +51,7 @@ class TypeExpressionComputerTest extends AbstractTclTest{
 		when(innerTypeReferenceUtil.isANumber(expectedType)).thenReturn(true)
 		
 		// when
-		val result = expressionTypeComputer.determineType(content, expectedType)
+		val result = expressionTypeComputer.determineType(content, Optional.of(expectedType))
 		
 		// then
 		typeReferenceUtil.isLong(result).assertTrue		
@@ -64,7 +65,7 @@ class TypeExpressionComputerTest extends AbstractTclTest{
 		when(innerTypeReferenceUtil.isANumber(expectedType)).thenReturn(true)
 		
 		// when
-		val result = expressionTypeComputer.determineType(content, expectedType)
+		val result = expressionTypeComputer.determineType(content, Optional.of(expectedType))
 		
 		// then
 		typeReferenceUtil.isInt(result).assertTrue		
@@ -78,7 +79,7 @@ class TypeExpressionComputerTest extends AbstractTclTest{
 		when(innerTypeReferenceUtil.isString(expectedType)).thenReturn(true)
 		
 		// when
-		val result = expressionTypeComputer.determineType(content, expectedType)
+		val result = expressionTypeComputer.determineType(content, Optional.of(expectedType))
 		
 		// then
 		typeReferenceUtil.isString(result).assertTrue		
@@ -93,7 +94,7 @@ class TypeExpressionComputerTest extends AbstractTclTest{
 		when(innerTypeReferenceUtil.longObjectJvmTypeReference).thenReturn(typeReferenceUtil.longObjectJvmTypeReference)
 		
 		// when
-		val result = expressionTypeComputer.determineType(content, expectedType)
+		val result = expressionTypeComputer.determineType(content, Optional.of(expectedType))
 		
 		// then
 		typeReferenceUtil.isBoolean(result).assertFalse
@@ -108,7 +109,7 @@ class TypeExpressionComputerTest extends AbstractTclTest{
 		when(innerTypeReferenceUtil.isANumber(expectedType)).thenReturn(true)
 
 		// when
-		val result = expressionTypeComputer.determineType(content, expectedType)
+		val result = expressionTypeComputer.determineType(content, Optional.of(expectedType))
 
 		// then
 		typeReferenceUtil.isANumber(result).assertTrue

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/validation/TclVarUsageValidatorTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/validation/TclVarUsageValidatorTest.xtend
@@ -99,7 +99,7 @@ class TclVarUsageValidatorTest extends AbstractParserTestWithDummyComponent {
 		tclModel.addToResourceSet('Test.tcl')
 		
 		// then
-		// assignment to a map dereferenced with a key is allowed (results in a put)
+		// assignment to a json dereferenced with a key is allowed (results in a put)
 		tclModel.assertNoErrors
 	}
 	

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/SimpleTypeComputer.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/SimpleTypeComputer.xtend
@@ -104,8 +104,8 @@ class SimpleTypeComputer {
 		val parameterTypeMap = getVariablesWithTypes(templateContainer)
 		val templateParameter = getTemplateParameterForCallingStepContent(stepContent)
 		val expectedType = parameterTypeMap.get(templateParameter)
-		if (expectedType === null || !expectedType.present) {
-			throw new RuntimeException("Unknown type")
+		if (expectedType === null) {
+			return Optional.empty
 		}
 		return expectedType
 	}

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclAssertCallBuilder.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclAssertCallBuilder.xtend
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.testeditor.tcl.dsl.jvmmodel
 
+import java.util.Optional
 import javax.inject.Inject
 import org.apache.commons.lang3.StringEscapeUtils
 import org.eclipse.xtext.common.types.JvmTypeReference
@@ -135,7 +136,7 @@ class TclAssertCallBuilder {
 		if (comparison.comparator == null) {
 			return expressionBuilder.buildReadExpression(comparison.left)
 		}
-		val wantedType = expressionTypeComputer.coercedTypeOfComparison(comparison, null)
+		val wantedType = expressionTypeComputer.coercedTypeOfComparison(comparison, Optional.empty)
 		val builtRightExpression=expressionBuilder.buildReadExpression(comparison.right, wantedType)
 		val builtLeftExpression=expressionBuilder.buildReadExpression(comparison.left, wantedType)
 		typeReferenceUtil.initWith(comparison.eResource)

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclExpressionBuilder.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclExpressionBuilder.xtend
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.testeditor.tcl.dsl.jvmmodel
 
+import java.util.Optional
 import javax.inject.Inject
 import org.eclipse.xtext.common.types.JvmTypeReference
 import org.testeditor.aml.Variable
@@ -23,13 +24,13 @@ import org.testeditor.tcl.ComparatorMatches
 import org.testeditor.tcl.Comparison
 import org.testeditor.tcl.EnvironmentVariable
 import org.testeditor.tcl.Expression
+import org.testeditor.tcl.JsonBoolean
+import org.testeditor.tcl.JsonNull
 import org.testeditor.tcl.JsonNumber
 import org.testeditor.tcl.JsonString
+import org.testeditor.tcl.JsonValue
 import org.testeditor.tcl.VariableReference
 import org.testeditor.tcl.VariableReferencePathAccess
-import org.testeditor.tcl.JsonBoolean
-import org.testeditor.tcl.JsonValue
-import org.testeditor.tcl.JsonNull
 
 /**
  * build a (textual) java expression based on a parsed (tcl) expression
@@ -90,7 +91,7 @@ class TclExpressionBuilder {
 
 	def String buildReadExpression(Expression compared, JvmTypeReference wantedType) {
 		coercionComputer.initWith(compared?.eResource)
-		val typeOfCompared = typeComputer.determineType(compared, wantedType)
+		val typeOfCompared = typeComputer.determineType(compared, Optional.of(wantedType))
 		val builtExpression = buildReadExpression(compared)
 		return coercionComputer.generateCoercion(wantedType, typeOfCompared, builtExpression)
 	}

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclExpressionTypeComputer.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclExpressionTypeComputer.xtend
@@ -14,6 +14,7 @@ package org.testeditor.tcl.dsl.jvmmodel
 
 import java.text.NumberFormat
 import java.text.ParseException
+import java.util.Optional
 import java.util.regex.Pattern
 import javax.inject.Inject
 import org.eclipse.xtext.EcoreUtil2
@@ -61,25 +62,25 @@ class TclExpressionTypeComputer {
 		}
 	}
 	
-	def dispatch JvmTypeReference determineType(StepContent stepContent, JvmTypeReference expectedType) {
+	def dispatch JvmTypeReference determineType(StepContent stepContent, Optional<JvmTypeReference> expectedType) {
 		typeReferenceUtil.initWith(stepContent.eResource)
 		val nonFractionalNumberPattern = Pattern.compile("(\\+|\\-)?[0-9]+")
 		val fractionalNumberPattern = Pattern.compile("(\\+|\\-)?[0-9]+(\\.[0-9]+)?")
 		val booleanPattern = Pattern.compile("true|false", Pattern.CASE_INSENSITIVE)
-		switch stepContent {			
+		switch stepContent {
 			StepContentVariable: {
-				if(expectedType !== null) {
-					if (typeReferenceUtil.isString(expectedType)) {
-						return expectedType
+				if(expectedType.present) {
+					if (typeReferenceUtil.isString(expectedType.get)) {
+						return expectedType.get
 					}
-					if (typeReferenceUtil.isBoolean(expectedType) && booleanPattern.matcher(stepContent.value).matches) {
-						return expectedType
+					if (typeReferenceUtil.isBoolean(expectedType.get) && booleanPattern.matcher(stepContent.value).matches) {
+						return expectedType.get
 					}
 					val NumberFormat nf = NumberFormat.instance
 					try {
 						nf.parse(stepContent.value)
-						if (typeReferenceUtil.isANumber(expectedType)) {
-							return expectedType
+						if (typeReferenceUtil.isANumber(expectedType.get)) {
+							return expectedType.get
 						}
 					}catch(ParseException pe) {
 						// ignore and try to find type by matching (see fallback below)
@@ -93,7 +94,7 @@ class TclExpressionTypeComputer {
 				} else if (fractionalNumberPattern.matcher(stepContent.value).matches) {
 					return typeReferenceUtil.bigDecimalJvmTypeReference
 				} else {
-					return typeReferenceUtil.stringJvmTypeReference
+					return typeReferenceUtil.stringJvmTypeReference // it is a string (as last resort)
 				}
 			}
 			VariableReference: return determineType(stepContent.variable, expectedType)
@@ -101,7 +102,7 @@ class TclExpressionTypeComputer {
 		}
 	}
 	
-	def dispatch JvmTypeReference determineType(Expression expression, JvmTypeReference expectedType) {
+	def dispatch JvmTypeReference determineType(Expression expression, Optional<JvmTypeReference> expectedType) {
 		typeReferenceUtil.initWith(expression.eResource)
 		switch expression {
 			VariableReferencePathAccess: return typeReferenceUtil.jsonElementJvmTypeReference
@@ -122,7 +123,7 @@ class TclExpressionTypeComputer {
 		}
 	}
 	
-	def dispatch JvmTypeReference determineType(Variable variable, JvmTypeReference expectedType) {
+	def dispatch JvmTypeReference determineType(Variable variable, Optional<JvmTypeReference> expectedType) {
 		typeReferenceUtil.initWith(variable.eResource)
 		switch variable {
 			AssignmentVariable : return typeComputer.determineType(variable)
@@ -134,7 +135,7 @@ class TclExpressionTypeComputer {
 	
 	def boolean coercibleTo(Expression expression, JvmTypeReference wantedType) {
 		coercionComputer.initWith(expression.eResource)
-		val expressionType = determineType(expression, wantedType)
+		val expressionType = determineType(expression, Optional.of(wantedType))
 		return coercionComputer.isCoercionPossible(wantedType, expressionType)
 	}
 	
@@ -147,7 +148,7 @@ class TclExpressionTypeComputer {
 	}
 	
 	/** find the most likely type for each of the comparison components (left and right) */
-	def JvmTypeReference coercedTypeOfComparison(Comparison comparison, JvmTypeReference wantedType) {
+	def JvmTypeReference coercedTypeOfComparison(Comparison comparison, Optional<JvmTypeReference> wantedType) {
 		typeReferenceUtil.initWith(comparison.eResource)
 		coercionComputer.initWith(comparison.eResource)
 		val leftType = comparison.left.determineType(wantedType)

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
@@ -449,7 +449,7 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 				output.trace(interaction.defaultMethod) => [
 					step.contents.filter(VariableReference).forEach [
 						val expectedType = typeComputer.getExpectedType(it, interaction)
-						val variableType = expressionTypeComputer.determineType(variable, expectedType.get)
+						val variableType = expressionTypeComputer.determineType(variable, expectedType)
 						if (coercionComputer.isCoercionPossible(expectedType.get, variableType)) {
 							val coercionCheck = generateCoercionCheck(interaction, expectedType)
 							if (!coercionCheck.nullOrEmpty) {
@@ -464,8 +464,10 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 				output.append('''// TODO interaction type '«interaction.name»' does not have a proper method reference''')
 			}
 		} else if (step.componentContext != null) {
+			logger.debug("interaction not found within context of component '{}' for test step='{}'.", step.componentContext.component.name, stepLog)
 			output.append('''org.junit.Assert.fail("Template '«StringEscapeUtils.escapeJava(stepLog)»' cannot be resolved with any known macro/fixture. Please check your «step.locationInfo»");''')
 		} else {
+			logger.debug("interaction not found in unknown context for test step='{}'.", stepLog)
 			output.append('''org.junit.Assert.fail("Template '«StringEscapeUtils.escapeJava(stepLog)»' cannot be resolved with any known macro/fixture. Please check your  Macro-, Config- or Testcase-File ");''')
 		}
 	}
@@ -473,16 +475,10 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 	private def String generateCoercionCheck(VariableReference variableReference, TemplateContainer templateContainer,
 		Optional<JvmTypeReference> expectedType) {
 		val variableAccessCode = toParameterString(variableReference, expectedType, templateContainer, false).head
-		val varRefType = expressionTypeComputer.determineType(variableReference.variable, expectedType.get)
+		val varRefType = expressionTypeComputer.determineType(variableReference.variable, expectedType)
 		val quotedErrorMessage = '''"Parameter is expected to be of type = '«expectedType.get.qualifiedName»' but a non coercible value = '"+«variableAccessCode».toString()+"' was passed through variable reference = '«variableReference.variable.name»'."'''
 		return coercionComputer.generateCoercionGuard(expectedType.get, varRefType, variableAccessCode,
 			quotedErrorMessage)
-	}
-	
-	private def String generateCoercionAround(VariableReference variableReference, String variableAccessCode,
-		Optional<JvmTypeReference> expectedType) {
-		val variableType = expressionTypeComputer.determineType(variableReference.variable, expectedType.get)
-		return coercionComputer.generateCoercion(expectedType.get, variableType, variableAccessCode)
 	}
 	
 	private def String getLocationInfo(TestStep step) {
@@ -516,7 +512,7 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 		if (macro !== null) {
 			step.contents.filter(VariableReference).forEach [
 				val expectedType = typeComputer.getExpectedType(it, macro)
-				val variableType = expressionTypeComputer.determineType(variable, expectedType.get)
+				val variableType = expressionTypeComputer.determineType(variable, expectedType)
 				if (coercionComputer.isCoercionPossible(expectedType.get, variableType)) { 
 					val coercionCheck = generateCoercionCheck(macro, expectedType)
 					if (!coercionCheck.nullOrEmpty) {
@@ -557,36 +553,46 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 	 * put it in quotes. If the type is not specified we assume a String to handle parameter passing gracefully.
 	 */
 	// TODO return type is only an iterable because of the locator strategy
-	private def Iterable<String> toParameterString(StepContent stepContent, Optional<JvmTypeReference> parameterType,
+	private def Iterable<String> toParameterString(StepContent stepContent, Optional<JvmTypeReference> expectedType,
 		TemplateContainer templateContainer, boolean withCoercion) {
-		// stepContent can be a reference to a variable or a value
-		if (stepContent instanceof VariableReference) {
-			// if variable reference forward the call to expressionBuilder
-			val parameterString = expressionBuilder.buildReadExpression(stepContent)
-			val expectedType = typeComputer.getExpectedType(stepContent, templateContainer)
-			val stepContentType = expressionTypeComputer.determineType(stepContent, expectedType.get)
-			val coercionPossible = coercionComputer.isCoercionPossible(expectedType.get, stepContentType)
-			if (withCoercion && coercionPossible) {
-				return #[generateCoercionAround(stepContent, parameterString, expectedType)]
-			}
-			return #[parameterString]
-		}
-		// Handle special case for locator + locator strategy
+			
+		// in case the parameter is an aml element, the locator + (optional) the locator strategy must be generated
 		if (templateContainer instanceof InteractionType) {
 			if (stepContent instanceof StepContentElement) {
 				return toLocatorParameterString(stepContent, templateContainer)
 			}
 		}
-		if (stepContent instanceof StepContentValue) {
-			// if value, check if type is String, if yes put it in quotes
-			val stepContentType = expressionTypeComputer.determineType(stepContent, null)
-			val contentIsLongOrBool = typeReferenceUtil.isLong(stepContentType) || typeReferenceUtil.isBoolean(stepContentType)
-			val isStringParameter = parameterType.present && typeReferenceUtil.isString(parameterType.get)
-			if (!isStringParameter && contentIsLongOrBool) {
-				return #[stepContent.value] // this may happen only, if the value is a boolean or a long
-			} else {
-				return #['''"«StringEscapeUtils.escapeJava(stepContent.value)»"''']
+
+		// in all other cases, check for necessary coercion
+		val parameterString = stepContent.contentToParameterString(expectedType, templateContainer)
+		// val expectedType = typeComputer.getExpectedType(stepContent, templateContainer)
+		if (expectedType.present) {
+			val stepContentType = expressionTypeComputer.determineType(stepContent, expectedType)
+			val coercionPossible = coercionComputer.isCoercionPossible(expectedType.get, stepContentType)
+			if (withCoercion && coercionPossible) {
+				return #[coercionComputer.generateCoercion(expectedType.get, stepContentType, parameterString)]
 			}
+		}
+		return #[parameterString]
+	}
+	
+	private def dispatch String contentToParameterString(VariableReference variableReference, Optional<JvmTypeReference> parameterType,
+		TemplateContainer templateContainer) {
+		return expressionBuilder.buildReadExpression(variableReference)
+	}
+	
+	private def dispatch String contentToParameterString(StepContentValue stepContentValue, Optional<JvmTypeReference> parameterType,
+		TemplateContainer templateContainer) {
+		val stepContentType = expressionTypeComputer.determineType(stepContentValue, parameterType)
+		val contentIsANumberOrBool = typeReferenceUtil.isANumber(stepContentType) || typeReferenceUtil.isBoolean(stepContentType)
+		val fixtureParameterTypeIsKnownToBeString = parameterType.present && typeReferenceUtil.isString(parameterType.get)
+		if (fixtureParameterTypeIsKnownToBeString || !contentIsANumberOrBool) {
+			// if fixture parameter is a string this is easy, just quote the value
+			// if the content itself is not a number nor a boolean its probably a good idea to quote this value, too
+			return '''"«StringEscapeUtils.escapeJava(stepContentValue.value)»"'''
+		} else {
+			// if content is definitely a boolean or a number and this is also expected by the called fixture,
+			return stepContentValue.value
 		}
 	}
 	

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/validation/TclValidator.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/validation/TclValidator.xtend
@@ -504,7 +504,7 @@ class TclValidator extends AbstractTclValidator {
 	private def void checkAgainstTypeExpectation(StepContent content, int contentIndex, JvmTypeReference expectedType) {
 		typeReferenceUtil.initWith(content.eResource)
 		coercionComputer.initWith(content.eResource)
-		val contentType = expressionTypeComputer.determineType(content, expectedType)
+		val contentType = expressionTypeComputer.determineType(content, Optional.of(expectedType))
 		val assignable = typeReferenceUtil.isAssignableFrom(expectedType, contentType)
 		// if content is a StepContentVariable, coercion is not option, since determineType already did check for bool/long/string
 		val coercible = !(content instanceof StepContentVariable) &&


### PR DESCRIPTION
- refactor  JvmTypeReference parameters to Optional<..>
- rename class under test to typeRefenceUtil in TclJvmTypeReferenceUtilTest
- refactor TclJvmModelInferer.toParameterString

no semantic changes