### PR TITLE
Fix/np in determine type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,6 @@ tcl/org.testeditor.tcl.model/text/
 tsl/org.testeditor.tsl.model/text/
 common/org.testeditor.dsl.common/text/
 
-
 ### Test Run Screenshots ###
 rcp/org.testeditor.rcp4.uatests/**/org.testeditor.*.png
 

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/SimpleTypeComputer.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/SimpleTypeComputer.xtend
@@ -23,7 +23,6 @@ import org.testeditor.aml.MethodReference
 import org.testeditor.aml.TemplateContainer
 import org.testeditor.aml.TemplateVariable
 import org.testeditor.dsl.common.util.CollectionUtils
-import org.testeditor.tcl.AbstractTestStep
 import org.testeditor.tcl.AssignmentVariable
 import org.testeditor.tcl.Macro
 import org.testeditor.tcl.TestStep
@@ -100,6 +99,8 @@ class SimpleTypeComputer {
 
 	/**
 	 * get the type that this stepContent is expected to have in order to satisfy the parameter type of its transitively called fixture
+	 * 
+	 * ensures that non null is returned
 	 */
 	def Optional<JvmTypeReference> getExpectedType(StepContent stepContent, TemplateContainer templateContainer) {
 		val templateParameter = getTemplateParameterForCallingStepContent(stepContent)
@@ -107,7 +108,9 @@ class SimpleTypeComputer {
 	}
 
 	/**
-	 * get the type that this template variable is expected to have in order to satisfy the parameter type of its transitively called fixture
+	 * get the type that this template variable is expected to have in order to satisfy the parameter type of its transitively called fixture.
+	 * 
+	 * ensures that non null is returned
 	 */
 	def Optional<JvmTypeReference> getExpectedType(TemplateVariable templateParameter, TemplateContainer templateContainer) {
 		val parameterTypeMap = getVariablesWithTypes(templateContainer)

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclCoercionComputer.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclCoercionComputer.xtend
@@ -117,8 +117,9 @@ class TclCoercionComputer {
 			case targetType.isNumber: return sourceType.isString || sourceType.isJson || sourceType.isLong || sourceType.isInt || sourceType.isBigDecimal || sourceType.isANumber
 			case targetType.isBigDecimal: return sourceType.isString || sourceType.isJson || sourceType.isLong || sourceType.isInt || sourceType.isBigDecimal || sourceType.isANumber
 			case targetType.isEnum: return sourceType.isString || sourceType.isJson || sourceType.isEnum
+			default: // ignore, simply return that coercion is not possible
+				return false
 		}
-		return false
 	}
 	
 	/**

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclExpressionBuilder.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclExpressionBuilder.xtend
@@ -57,7 +57,7 @@ class TclExpressionBuilder {
 			return buildReadExpression(comparison.left)
 		}
 		// check whether coercion of left or right is necessary		
-		val wantedTypeForComparison = typeComputer.coercedTypeOfComparison(comparison, null)
+		val wantedTypeForComparison = typeComputer.coercedTypeOfComparison(comparison, Optional.empty)
 		val validTypeBuiltRightExpression = buildReadExpression(comparison.right, wantedTypeForComparison)
 		val validTypeBuiltLeftExpression = buildReadExpression(comparison.left, wantedTypeForComparison)
 		
@@ -91,7 +91,7 @@ class TclExpressionBuilder {
 
 	def String buildReadExpression(Expression compared, JvmTypeReference wantedType) {
 		coercionComputer.initWith(compared?.eResource)
-		val typeOfCompared = typeComputer.determineType(compared, Optional.of(wantedType))
+		val typeOfCompared = typeComputer.determineType(compared, Optional.ofNullable(wantedType))
 		val builtExpression = buildReadExpression(compared)
 		return coercionComputer.generateCoercion(wantedType, typeOfCompared, builtExpression)
 	}

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclExpressionTypeComputer.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclExpressionTypeComputer.xtend
@@ -57,7 +57,7 @@ class TclExpressionTypeComputer {
 		switch expression {
 			JsonValue: return true // supertype of all (relevant) json types (e.g. JsonObject, JsonArray, JsonString ...)
 			VariableReferencePathAccess: return true // since this is only allowed for json types, the result is a json type, too
-			VariableReference: return jsonUtil.isJsonType(determineType(expression, null))
+			VariableReference: return jsonUtil.isJsonType(determineType(expression, Optional.empty))
 			default: return false
 		}
 	}

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclExpressionTypeComputer.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclExpressionTypeComputer.xtend
@@ -69,7 +69,7 @@ class TclExpressionTypeComputer {
 		val booleanPattern = Pattern.compile("true|false", Pattern.CASE_INSENSITIVE)
 		switch stepContent {
 			StepContentVariable: {
-				if(expectedType.present) {
+				if((expectedType?:Optional.empty).present) {
 					if (typeReferenceUtil.isString(expectedType.get)) {
 						return expectedType.get
 					}
@@ -97,7 +97,7 @@ class TclExpressionTypeComputer {
 					return typeReferenceUtil.stringJvmTypeReference // it is a string (as last resort)
 				}
 			}
-			VariableReference: return determineType(stepContent.variable, expectedType)
+			VariableReference: return determineType(stepContent.variable, expectedType?:Optional.empty)
 			default: throw new RuntimeException('''Unknown step content type = '«stepContent.class.name»' for type determination.''')
 		}
 	}
@@ -112,9 +112,9 @@ class TclExpressionTypeComputer {
 			JsonString: return typeReferenceUtil.stringJvmTypeReference
 			JsonBoolean: return typeReferenceUtil.booleanObjectJvmTypeReference
 			JsonNull: throw new RuntimeException("Not implemented yet")
-			VariableReference: return expression.variable.determineType(expectedType)
+			VariableReference: return expression.variable.determineType(expectedType?:Optional.empty)
 			Comparison: if(expression.comparator === null) {
-				expression.left.determineType(expectedType)
+				expression.left.determineType(expectedType?:Optional.empty)
 			} else {
 				return typeReferenceUtil.booleanPrimitiveJvmTypeReference
 			}
@@ -125,12 +125,17 @@ class TclExpressionTypeComputer {
 	
 	def dispatch JvmTypeReference determineType(Variable variable, Optional<JvmTypeReference> expectedType) {
 		typeReferenceUtil.initWith(variable.eResource)
-		switch variable {
-			AssignmentVariable : return typeComputer.determineType(variable)
-			EnvironmentVariable : return typeReferenceUtil.stringJvmTypeReference
-			TemplateVariable: return typeComputer.getVariablesWithTypes(EcoreUtil2.getContainerOfType(variable, TemplateContainer)).get(variable).get
-			default: throw new RuntimeException("Variable of type'"+variable.class.canonicalName+"' is unknown")
+		val result = switch variable {
+			AssignmentVariable: typeComputer.determineType(variable)
+			EnvironmentVariable: typeReferenceUtil.stringJvmTypeReference
+			TemplateVariable: typeComputer.getVariablesWithTypes(
+				EcoreUtil2.getContainerOfType(variable, TemplateContainer)).get(variable).get
+			default: throw new RuntimeException('''Variable of type='«variable.class.canonicalName»' is unknown''')
 		}
+		if (result === null) {
+			throw new RuntimeException('''Type of variable='«variable.name»' could not be determined. Please check you classpath setup.''')
+		}
+		return result
 	}
 	
 	def boolean coercibleTo(Expression expression, JvmTypeReference wantedType) {
@@ -151,11 +156,11 @@ class TclExpressionTypeComputer {
 	def JvmTypeReference coercedTypeOfComparison(Comparison comparison, Optional<JvmTypeReference> wantedType) {
 		typeReferenceUtil.initWith(comparison.eResource)
 		coercionComputer.initWith(comparison.eResource)
-		val leftType = comparison.left.determineType(wantedType)
+		val leftType = comparison.left.determineType(wantedType?:Optional.empty)
 		if (comparison.comparator === null) { // just a simple expression without the right component ?
 			return leftType
 		}
-		val rightType = comparison.right.determineType(wantedType)
+		val rightType = comparison.right.determineType(wantedType?:Optional.empty)
 		switch (comparison.comparator) {
 			ComparatorMatches:
 				return typeReferenceUtil.stringJvmTypeReference // when matching, both components must be strings

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
@@ -395,7 +395,7 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 	}
 	
 	private def dispatch void toUnitTestCodeLine(AssignmentThroughPath step, ITreeAppendable output) {
-		val varType = expressionTypeComputer.determineType(step.variableReference.variable, null)
+		val varType = expressionTypeComputer.determineType(step.variableReference.variable, Optional.empty)
 		if (jsonUtil.isJsonType(varType)) {
 			toUnitTestCodeLineOfJsonAssignment(step, output)
 		} else {
@@ -420,7 +420,7 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 			VariableReferencePathAccess,
 			VariableReference: {
 				val valueString = expressionBuilder.buildReadExpression(step.expression)
-				val variableType = expressionTypeComputer.determineType(expression, null)
+				val variableType = expressionTypeComputer.determineType(expression, Optional.empty)
 				if (jsonUtil.isJsonType(variableType)) {
 					val code = '''«expressionBuilder.buildWriteExpression(varRef, valueString)»;'''
 					output.append(code)

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
@@ -449,9 +449,9 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 				output.trace(interaction.defaultMethod) => [
 					step.contents.filter(VariableReference).forEach [
 						val expectedType = typeComputer.getExpectedType(it, interaction)
-						val variableType = expressionTypeComputer.determineType(variable, expectedType)
+						val variableType = expressionTypeComputer.determineType(variable, expectedType?:Optional.empty)
 						if (coercionComputer.isTypeCoercionPossible(expectedType.get, variableType)) {
-							val coercionCheck = generateCoercionCheck(interaction, expectedType)
+							val coercionCheck = generateCoercionCheck(interaction, expectedType?:Optional.empty)
 							if (!coercionCheck.nullOrEmpty) {
 								output.append(coercionCheck).newLine
 							}
@@ -475,7 +475,7 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 	private def String generateCoercionCheck(VariableReference variableReference, TemplateContainer templateContainer,
 		Optional<JvmTypeReference> expectedType) {
 		val variableAccessCode = toParameterString(variableReference, expectedType, templateContainer, false).head
-		val varRefType = expressionTypeComputer.determineType(variableReference.variable, expectedType)
+		val varRefType = expressionTypeComputer.determineType(variableReference.variable, expectedType?:Optional.empty)
 		val quotedErrorMessage = '''"Parameter is expected to be of type = '«expectedType.get.qualifiedName»' but a non coercible value = '"+«variableAccessCode».toString()+"' was passed through variable reference = '«variableReference.variable.name»'."'''
 		return coercionComputer.generateCoercionGuard(expectedType.get, varRefType, variableAccessCode,
 			quotedErrorMessage)
@@ -512,8 +512,8 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 		if (macro !== null) {
 			step.contents.filter(VariableReference).forEach [
 				val expectedType = typeComputer.getExpectedType(it, macro)
-				val variableType = expressionTypeComputer.determineType(variable, expectedType)
-				if (coercionComputer.isTypeCoercionPossible(expectedType.get, variableType)) { 
+				val variableType = expressionTypeComputer.determineType(variable, expectedType?:Optional.empty)
+				if ((expectedType?:Optional.empty).present && coercionComputer.isTypeCoercionPossible(expectedType.get, variableType)) { 
 					val coercionCheck = generateCoercionCheck(macro, expectedType)
 					if (!coercionCheck.nullOrEmpty) {
 						output.append(coercionCheck).newLine
@@ -564,9 +564,9 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 		}
 
 		// in all other cases, check for necessary coercion
-		val parameterString = stepContent.contentToParameterString(expectedType, templateContainer)
+		val parameterString = stepContent.contentToParameterString(expectedType?:Optional.empty, templateContainer)
 		// val expectedType = typeComputer.getExpectedType(stepContent, templateContainer)
-		if (expectedType.present) {
+		if ((expectedType?:Optional.empty).present) {
 			val stepContentType = expressionTypeComputer.determineType(stepContent, expectedType)
 			val coercionPossible = coercionComputer.isTypeCoercionPossible(expectedType.get, stepContentType)
 			if (withCoercion && coercionPossible) {
@@ -583,7 +583,7 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 	
 	private def dispatch String contentToParameterString(StepContentValue stepContentValue, Optional<JvmTypeReference> parameterType,
 		TemplateContainer templateContainer) {
-		val stepContentType = expressionTypeComputer.determineType(stepContentValue, parameterType)
+		val stepContentType = expressionTypeComputer.determineType(stepContentValue, parameterType?:Optional.empty)
 		val contentIsANumberOrBool = typeReferenceUtil.isANumber(stepContentType) || typeReferenceUtil.isBoolean(stepContentType)
 		val fixtureParameterTypeIsKnownToBeString = parameterType.present && typeReferenceUtil.isString(parameterType.get)
 		if (fixtureParameterTypeIsKnownToBeString || !contentIsANumberOrBool) {

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmTypeReferenceUtil.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmTypeReferenceUtil.xtend
@@ -128,6 +128,9 @@ class TclJvmTypeReferenceUtil {
 	// use xbase to check for assignablility
 	def boolean isAssignableFrom(JvmTypeReference target, JvmTypeReference source,
 		TypeConformanceComputationArgument argument) {
+		if (target === null || source === null) {
+			throw new RuntimeException("For testing assignment source and target types must not be null")
+		}
 		if (typeReferenceOwner === null) {
 			typeReferenceOwner = new StandardTypeReferenceOwner(services, resourceSet)
 		}

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/validation/TclValidator.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/validation/TclValidator.xtend
@@ -504,7 +504,7 @@ class TclValidator extends AbstractTclValidator {
 	private def void checkAgainstTypeExpectation(StepContent content, int contentIndex, JvmTypeReference expectedType) {
 		typeReferenceUtil.initWith(content.eResource)
 		coercionComputer.initWith(content.eResource)
-		val contentType = expressionTypeComputer.determineType(content, Optional.of(expectedType))
+		val contentType = expressionTypeComputer.determineType(content, Optional.ofNullable(expectedType))
 		val assignable = typeReferenceUtil.isAssignableFrom(expectedType, contentType)
 		// if content is a StepContentVariable, coercion is not option, since determineType already did check for bool/long/string
 		val coercible = coercionComputer.isCoercionPossible(expectedType, contentType, content)


### PR DESCRIPTION
Make the use of optional more robust. 
- Make sure that parameters passed as optional are never null.
- Add null tests to parameters that are of type optional