### PR TITLE
handle different test step types in CallTreeBuilder

### DIFF
--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/CallTreeBuilderTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/CallTreeBuilderTest.xtend
@@ -1,101 +1,115 @@
 package org.testeditor.tcl.dsl.jvmmodel
 
 import javax.inject.Inject
+import org.junit.Before
 import org.junit.Test
+import org.testeditor.aml.AmlModel
+import org.testeditor.aml.Component
+import org.testeditor.aml.dsl.tests.AmlModelGenerator
+import org.testeditor.dsl.common.testing.DslParseHelper
+import org.testeditor.dsl.common.testing.DummyFixture
 import org.testeditor.tcl.dsl.tests.AbstractTclTest
 import org.testeditor.tcl.dsl.tests.TclModelGenerator
 import org.testeditor.tcl.impl.TclFactoryImpl
-import org.testeditor.tcl.util.ExampleAmlModel
 
 class CallTreeBuilderTest extends AbstractTclTest {
-	
+
+	@Inject extension DslParseHelper parserHelper
 	@Inject extension TclModelGenerator tclModelGenerator
+	@Inject extension AmlModelGenerator
 	@Inject extension TclFactoryImpl tclFactory
-	@Inject ExampleAmlModel amlModel
 	@Inject CallTreeBuilder builderUnderTest
-	
-	
+
+	AmlModel amlModelForTesting
+	Component amlComponentForTesting
+
+	@Before
+	def void setupAmlAndDummyFixture() {
+		amlModelForTesting = parseAml(DummyFixture.amlModel)
+		amlComponentForTesting = amlModelForTesting.components.findFirst[name == "GreetingApplication"]
+	}
+
 	@Test
 	def void returnsSingleCallTreeNodeForEmptyTestCase() {
-		//given
+		// given
 		val testCase = testCase('TheTestCase')
-		
+
 		// when
 		val actualNode = builderUnderTest.buildCallTree(testCase)
-		
-		//then
+
+		// then
 		actualNode.displayname.assertEquals('TheTestCase')
 		actualNode.children.assertEmpty
 	}
-	
+
 	@Test
 	def void returnsProperCallTreeForTestCaseWithSpecificationStepImplementations() {
-		//given
+		// given
 		val testCase = testCase('TheTestCase') => [
 			steps += specificationStep('My', 'first', 'test', 'step')
 		]
-		
+
 		// when
 		val actualTree = builderUnderTest.buildCallTree(testCase)
-		
-		//then
+
+		// then
 		actualTree.displayname.assertEquals('TheTestCase')
 		actualTree.children => [
 			assertSize(1)
 			head.displayname.assertEquals('My first test step')
 		]
 	}
-	
+
 	@Test
 	def void returnsProperCallTreeForTestCaseWithCleanup() {
-		//given
+		// given
 		val testCase = testCase('TheTestCase') => [
 			cleanup += createTestCleanup
 		]
-		
+
 		// when
 		val actualTree = builderUnderTest.buildCallTree(testCase)
-		
-		//then
+
+		// then
 		actualTree.children => [
 			assertSize(1)
 			head.displayname.assertEquals('Cleanup')
 		]
 	}
-	
+
 	@Test
 	def void returnsProperCallTreeForTestCaseWithSetup() {
-		//given
+		// given
 		val testCase = testCase('TheTestCase') => [
 			setup += createTestSetup
 		]
-		
+
 		// when
 		val actualTree = builderUnderTest.buildCallTree(testCase)
-		
-		//then
+
+		// then
 		actualTree.children => [
 			assertSize(1)
 			head.displayname.assertEquals('Setup')
 		]
 	}
-	
+
 	/**
 	 * Under a test case, setup always comes first, then the test steps, then the cleanup.
 	 */
 	@Test
 	def void returnsCallTreeWithProperlyOrderedSubElements() {
-		//given
+		// given
 		val testCase = testCase('TheTestCase') => [
 			setup += createTestSetup
 			steps += specificationStep('My', 'first', 'test', 'step')
 			cleanup += createTestCleanup
 		]
-		
+
 		// when
 		val actualTree = builderUnderTest.buildCallTree(testCase)
-		
-		//then
+
+		// then
 		actualTree.children => [
 			assertSize(3)
 			get(0).displayname.assertEquals('Setup')
@@ -103,64 +117,175 @@ class CallTreeBuilderTest extends AbstractTclTest {
 			get(2).displayname.assertEquals('Cleanup')
 		]
 	}
-	
+
 	@Test
 	def void returnsProperCallTreeForTestCaseWithComponentContext() {
-		//given
+		// given
 		val testCase = testCase('TheTestCase') => [
 			steps += specificationStep('My', 'first', 'test', 'step') => [
-				contexts += componentTestStepContext(amlModel.myDialog)
+				contexts += componentTestStepContext(amlComponentForTesting)
 			]
 		]
-		
+
 		// when
 		val actualTree = builderUnderTest.buildCallTree(testCase)
-		
-		//then
+
+		// then
 		actualTree.children.head.children => [
 			assertSize(1)
-			head.displayname.assertEquals(amlModel.myDialog.name)
+			head.displayname.assertEquals(amlComponentForTesting.name)
 		]
 	}
-	
+
 	@Test
 	def void returnsProperCallTreeForTestCaseWithMacroContext() {
-		//given		
+		// given		
 		val testCase = testCase('TheTestCase') => [
 			steps += specificationStep('My', 'first', 'test', 'step') => [
 				contexts += macroTestStepContext(macroCollection('MyMacroCollection'))
 			]
 		]
-		
+
 		// when
 		val actualTree = builderUnderTest.buildCallTree(testCase)
-		
-		//then
+
+		// then
 		actualTree.children.head.children => [
 			assertSize(1)
 			head.displayname.assertEquals('MyMacroCollection')
 		]
 	}
-	
+
 	@Test
 	def void returnsProperCallTreeForTestCaseWithTestStepsInComponentContext() {
-		//given
+		// given
 		val testCase = testCase('TheTestCase') => [
 			steps += specificationStep('My', 'first', 'test', 'step') => [
-				contexts += componentTestStepContext(amlModel.myDialog) => [
+				contexts += componentTestStepContext(amlComponentForTesting) => [
 					steps += testStep('Wait', 'for').withParameter('60').withText('seconds')
 				]
 			]
 		]
-		
+
 		// when
 		val actualTree = builderUnderTest.buildCallTree(testCase)
-		
-		//then
+
+		// then
 		actualTree.children.head.children.head.children => [
 			assertSize(1)
 			head.displayname.assertEquals('Wait for "60" seconds')
 		]
 	}
-	
+
+	@Test
+	def void returnsProperCallTreeForTestCaseWithTestStepWithAssignment() {
+		// given
+		val testCase = testCase('TheTestCase') => [
+			steps += specificationStep('My', 'first', 'test', 'step') => [
+				contexts += componentTestStepContext(amlComponentForTesting) => [
+					steps += testStepWithAssignment('myVar', 'Read', 'jsonObject', 'from').withElement('bar')
+				]
+			]
+		]
+
+		// when
+		val actualTree = builderUnderTest.buildCallTree(testCase)
+
+		// then
+		actualTree.children.head.children.head.children => [
+			assertSize(1)
+			head.displayname.assertEquals('com.google.gson.JsonObject myVar = Read jsonObject from <bar>')
+		]
+	}
+
+	@Test
+	def void returnsProperCallTreeForTestCaseWithAssertionTestStep() {
+		// given
+		val tclModel = '''
+			package com.example
+			# TheTestCase
+			* My first test step
+				Component: GreetingApplication
+				- isVisible = Is <bar> visible?
+				- assert isVisible
+		'''.toString.parseTcl('TheTestCase.tcl')
+
+		// when
+		val actualTree = builderUnderTest.buildCallTree(tclModel.test)
+
+		// then
+		actualTree.children.head.children.head.children => [
+			assertSize(2)
+			last.displayname.assertEquals('assert isVisible')
+		]
+	}
+
+	@Test
+	def void returnsProperCallTreeForTestCaseWithAssignmentThroughPath() {
+		// given
+		val tclModel = '''
+			package com.example
+			# TheTestCase
+			* My first test step
+				Component: GreetingApplication
+				- obj = Read jsonObject from <bar>
+				- obj."key"[42] = 1 = 2
+		'''.toString.parseTcl('TheTestCase.tcl')
+
+		// when
+		val actualTree = builderUnderTest.buildCallTree(tclModel.test)
+
+		// then
+		actualTree.children.head.children.head.children => [
+			assertSize(2)
+			last.displayname.assertEquals('@obj."key"[42] = 1 = 2')
+		]
+	}
+
+	@Test
+	def void returnsProperCallTreeForTestCaseWithTestStepsInMacroContext() {
+		// given
+		val macros = macroCollection('MyMacros') => [
+			macros += macro('macro1') => [
+				val templateVar = templateVariable('param')
+				template = template("read").withParameter(templateVar)
+				contexts += componentTestStepContext(amlComponentForTesting) => [
+					steps += testStepWithAssignment('myVar', 'Read', 'jsonObject', 'from').withElement('bar')
+				]
+
+			]
+		]
+		val tclModel = tclModel => [
+			macroCollection = macros
+			test = testCase('TheTestCase') => [
+				steps += specificationStep('My', 'first', 'test', 'step') => [
+					contexts += macroTestStepContext(macros) => [
+						steps += testStep('read').withParameter('bar')
+					]
+				]
+			]
+		]
+
+		// when
+		val actualTree = builderUnderTest.buildCallTree(tclModel.test)
+
+		// then
+		actualTree.children.head.children.head.children => [
+			assertSize(1, 'there should exactly be one test step (macro invocation)')
+			head => [
+				displayname.assertEquals('read "bar"')
+				children => [
+					assertSize(1, 'there should be exactly one component context declaration')
+					head => [
+						displayname.assertEquals(amlComponentForTesting.name)
+						children => [
+							assertSize(1, 'there should be exactly one test step (component invocation)')
+							head.displayname.assertEquals('com.google.gson.JsonObject myVar = Read jsonObject from <bar>')
+						]
+					]
+				]
+			]
+		]
+	}
+
 }

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/CallTreeBuilderTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/CallTreeBuilderTest.xtend
@@ -194,7 +194,7 @@ class CallTreeBuilderTest extends AbstractTclTest {
 		// then
 		actualTree.children.head.children.head.children => [
 			assertSize(1)
-			head.displayname.assertEquals('com.google.gson.JsonObject myVar = Read jsonObject from <bar>')
+			head.displayname.assertEquals('myVar = Read jsonObject from <bar> [com.google.gson.JsonObject]')
 		]
 	}
 
@@ -280,7 +280,7 @@ class CallTreeBuilderTest extends AbstractTclTest {
 						displayname.assertEquals(amlComponentForTesting.name)
 						children => [
 							assertSize(1, 'there should be exactly one test step (component invocation)')
-							head.displayname.assertEquals('com.google.gson.JsonObject myVar = Read jsonObject from <bar>')
+							head.displayname.assertEquals('myVar = Read jsonObject from <bar> [com.google.gson.JsonObject]')
 						]
 					]
 				]

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/SimpleTclGeneratorIntegrationTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/SimpleTclGeneratorIntegrationTest.xtend
@@ -100,13 +100,13 @@ class SimpleTclGeneratorIntegrationTest extends AbstractTclGeneratorIntegrationT
 			  
 			  reporter.enter(TestRunReporter.SemanticUnit.COMPONENT, "GreetingApplication");
 			  
-			  reporter.enter(TestRunReporter.SemanticUnit.STEP, "java.util.List<? extends java.lang.Object> foo = Read list from <bar>");
+			  reporter.enter(TestRunReporter.SemanticUnit.STEP, "foo = Read list from <bar> [java.util.List<? extends java.lang.Object>]");
 			  java.util.List<? extends java.lang.Object> foo = dummyFixture.getList("label.greet");
-			  reporter.enter(TestRunReporter.SemanticUnit.STEP, "java.lang.String baz = Read value from <bar>");
+			  reporter.enter(TestRunReporter.SemanticUnit.STEP, "baz = Read value from <bar> [java.lang.String]");
 			  java.lang.String baz = dummyFixture.getValue("label.greet");
-			  reporter.enter(TestRunReporter.SemanticUnit.STEP, "boolean book = Read bool from <bar>");
+			  reporter.enter(TestRunReporter.SemanticUnit.STEP, "book = Read bool from <bar> [boolean]");
 			  boolean book = dummyFixture.getBool("label.greet");
-			  reporter.enter(TestRunReporter.SemanticUnit.STEP, "com.google.gson.JsonObject mak = Read jsonObject from <bar>");
+			  reporter.enter(TestRunReporter.SemanticUnit.STEP, "mak = Read jsonObject from <bar> [com.google.gson.JsonObject]");
 			  com.google.gson.JsonObject mak = dummyFixture.getJsonObject("label.greet");
 			  reporter.enter(TestRunReporter.SemanticUnit.STEP, "assert foo // foo = '" + foo + "'");
 			  org.junit.Assert.assertNotNull("SimpleTest.tcl:11: foo", foo);
@@ -130,7 +130,7 @@ class SimpleTclGeneratorIntegrationTest extends AbstractTclGeneratorIntegrationT
 			  org.junit.Assert.assertNull("SimpleTest.tcl:20: ! mak.\"key with spaces\"", mak.getAsJsonObject().get("key with spaces"));
 			  reporter.enter(TestRunReporter.SemanticUnit.STEP, "assert baz = mak.otherkey // baz = '" + baz + "', mak = '" + mak + "'");
 			  org.junit.Assert.assertEquals("SimpleTest.tcl:21: baz = mak.otherkey", mak.getAsJsonObject().get("otherkey").getAsJsonPrimitive().getAsString(), baz);
-			  reporter.enter(TestRunReporter.SemanticUnit.STEP, "long log = Read long from <bar>");
+			  reporter.enter(TestRunReporter.SemanticUnit.STEP, "log = Read long from <bar> [long]");
 			  long log = dummyFixture.getLong("label.greet");
 			  reporter.enter(TestRunReporter.SemanticUnit.STEP, "assert log < 42 // log = '" + log + "'");
 			  org.junit.Assert.assertTrue("SimpleTest.tcl:23: log < 42", log < 42);
@@ -192,15 +192,15 @@ class SimpleTclGeneratorIntegrationTest extends AbstractTclGeneratorIntegrationT
 
 		// then
 		generatedCode.assertContains('''
-			reporter.enter(TestRunReporter.SemanticUnit.STEP, "com.google.gson.JsonObject jsonvar = Read jsonObject from <bar>");
+			reporter.enter(TestRunReporter.SemanticUnit.STEP, "jsonvar = Read jsonObject from <bar> [com.google.gson.JsonObject]");
 			com.google.gson.JsonObject jsonvar = dummyFixture.getJsonObject("label.greet");
-			reporter.enter(TestRunReporter.SemanticUnit.STEP, "long longvar = Read long from <bar>");
+			reporter.enter(TestRunReporter.SemanticUnit.STEP, "longvar = Read long from <bar> [long]");
 			long longvar = dummyFixture.getLong("label.greet");
-			reporter.enter(TestRunReporter.SemanticUnit.STEP, "java.lang.String stringvar = Read value from <bar>");
+			reporter.enter(TestRunReporter.SemanticUnit.STEP, "stringvar = Read value from <bar> [java.lang.String]");
 			java.lang.String stringvar = dummyFixture.getValue("label.greet");
-			reporter.enter(TestRunReporter.SemanticUnit.STEP, "boolean boolvar = Read bool from <bar>");
+			reporter.enter(TestRunReporter.SemanticUnit.STEP, "boolvar = Read bool from <bar> [boolean]");
 			boolean boolvar = dummyFixture.getBool("label.greet");
-			reporter.enter(TestRunReporter.SemanticUnit.STEP, "org.testeditor.dsl.common.testing.DummyEnum enumvar = Read enum from <bar>");
+			reporter.enter(TestRunReporter.SemanticUnit.STEP, "enumvar = Read enum from <bar> [org.testeditor.dsl.common.testing.DummyEnum]");
 			org.testeditor.dsl.common.testing.DummyEnum enumvar = dummyFixture.getEnum("label.greet");
 			reporter.enter(TestRunReporter.SemanticUnit.STEP, "@jsonvar.\"key\" = jsonvar.\"some value\"");
 			jsonvar.getAsJsonObject().add("key", jsonvar.getAsJsonObject().get("some value"));
@@ -274,7 +274,7 @@ class SimpleTclGeneratorIntegrationTest extends AbstractTclGeneratorIntegrationT
 			  
 			  reporter.enter(TestRunReporter.SemanticUnit.STEP, "Start application \"org.testeditor.swing.exammple.Greetings\"");
 			  dummyFixture.startApplication("org.testeditor.swing.exammple.Greetings");
-			  reporter.enter(TestRunReporter.SemanticUnit.STEP, "java.util.List<? extends java.lang.Object> foo = Read list from <bar>");
+			  reporter.enter(TestRunReporter.SemanticUnit.STEP, "foo = Read list from <bar> [java.util.List<? extends java.lang.Object>]");
 			  java.util.List<? extends java.lang.Object> foo = dummyFixture.getList("label.greet");
 			  reporter.enter(TestRunReporter.SemanticUnit.STEP, "Stop application");
 			  dummyFixture.stopApplication();

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/TclParameterGeneratorIntegrationTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/TclParameterGeneratorIntegrationTest.xtend
@@ -96,9 +96,9 @@ class TclParameterGeneratorIntegrationTest extends AbstractTclGeneratorIntegrati
 			    
 			    reporter.enter(TestRunReporter.SemanticUnit.COMPONENT, "dummyComponent");
 			    
-			    reporter.enter(TestRunReporter.SemanticUnit.STEP, "com.google.gson.JsonObject myJsonObject = Read jsonObject from <dummyElement>");
+			    reporter.enter(TestRunReporter.SemanticUnit.STEP, "myJsonObject = Read jsonObject from <dummyElement> [com.google.gson.JsonObject]");
 			    com.google.gson.JsonObject myJsonObject = dummyFixture.getJsonObject("dummyLocator");
-			    reporter.enter(TestRunReporter.SemanticUnit.STEP, "java.lang.String myVal = Read value from <dummyElement>");
+			    reporter.enter(TestRunReporter.SemanticUnit.STEP, "myVal = Read value from <dummyElement> [java.lang.String]");
 			    java.lang.String myVal = dummyFixture.getValue("dummyLocator");
 			    reporter.enter(TestRunReporter.SemanticUnit.STEP, "Start application @myJsonObject.\"my key\" // myJsonObject = '" + myJsonObject + "'");
 			    org.junit.Assert.assertTrue("Parameter is expected to be of type = 'java.lang.String' but a non coercible value = '"+myJsonObject.getAsJsonObject().get("my key").toString()+"' was passed through variable reference = 'myJsonObject'.", myJsonObject.getAsJsonObject().get("my key").getAsJsonPrimitive().isString());

--- a/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/macro/MacroGeneratorIntegrationTest.xtend
+++ b/tcl/org.testeditor.tcl.dsl.tests/src/org/testeditor/tcl/dsl/jvmmodel/macro/MacroGeneratorIntegrationTest.xtend
@@ -143,7 +143,7 @@ class MacroGeneratorIntegrationTest extends org.testeditor.tcl.dsl.jvmmodel.Abst
 				  
 				  reporter.enter(TestRunReporter.SemanticUnit.COMPONENT, "GreetingApplication");
 				  
-				  reporter.enter(TestRunReporter.SemanticUnit.STEP, "java.lang.String value = Read value from <bar>");
+				  reporter.enter(TestRunReporter.SemanticUnit.STEP, "value = Read value from <bar> [java.lang.String]");
 				  java.lang.String value = dummyFixture.getValue("label.greet");
 				}
 			'''.indent(1))
@@ -237,7 +237,7 @@ class MacroGeneratorIntegrationTest extends org.testeditor.tcl.dsl.jvmmodel.Abst
 				  
 				  reporter.enter(TestRunReporter.SemanticUnit.COMPONENT, "GreetingApplication");
 				  
-				  reporter.enter(TestRunReporter.SemanticUnit.STEP, "java.lang.String value = Read value from <bar>");
+				  reporter.enter(TestRunReporter.SemanticUnit.STEP, "value = Read value from <bar> [java.lang.String]");
 				  java.lang.String value = dummyFixture.getValue("label.greet");
 				  // Macro: MyMacroCollection
 				  // - Set input to @value

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/CallTreeBuilder.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/CallTreeBuilder.xtend
@@ -3,29 +3,31 @@ package org.testeditor.tcl.dsl.jvmmodel
 import javax.inject.Inject
 import javax.inject.Singleton
 import org.eclipse.emf.ecore.EObject
+import org.testeditor.tcl.AbstractTestStep
 import org.testeditor.tcl.CallTreeNode
-import org.testeditor.tcl.ComponentTestStepContext
-import org.testeditor.tcl.MacroTestStepContext
 import org.testeditor.tcl.SpecificationStepImplementation
 import org.testeditor.tcl.StepContainer
 import org.testeditor.tcl.TestCase
 import org.testeditor.tcl.TestCleanup
 import org.testeditor.tcl.TestSetup
 import org.testeditor.tcl.TestStep
+import org.testeditor.tcl.TestStepContext
+import org.testeditor.tcl.dsl.messages.TclElementStringifier
 import org.testeditor.tcl.impl.TclFactoryImpl
 import org.testeditor.tcl.util.TclModelUtil
 
 @Singleton
 class CallTreeBuilder {
-	static  val testSetupDisplayName = 'Setup'
-	static  val testCleanupDisplayName = 'Cleanup'
-	
+
+	static val testSetupDisplayName = 'Setup'
+	static val testCleanupDisplayName = 'Cleanup'
+
 	@Inject extension TclFactoryImpl tclFactory
 	@Inject extension TclModelUtil
-	
+	@Inject extension TclElementStringifier
+
 	def CallTreeNode buildCallTree(TestCase model) {
-		return createCallTreeNode => [
-			displayname = model.name
+		return model.namedCallTreeNode => [
 			children += model.setup.map[toCallTree]
 			children += model.steps.map[toCallTree]
 			children += model.cleanup.map[toCallTree]
@@ -37,51 +39,49 @@ class CallTreeBuilder {
 			children += model.contexts.map[toCallTree]
 		]
 	}
-	
-	def dispatch CallTreeNode toCallTree(ComponentTestStepContext model) {
-		return callTreeNodeNamed(model.component.name) => [
+
+	def dispatch CallTreeNode toCallTree(TestStepContext model) {
+		return model.namedCallTreeNode => [
 			children += model.steps.map[toCallTree]
 		]
 	}
 
-	def dispatch CallTreeNode toCallTree(MacroTestStepContext model) {
-		return callTreeNodeNamed(model.macroCollection.name)
-	}
-	
-	// ToDo: (potentially recursive) Macro calls
-	
-	
-	def dispatch CallTreeNode toCallTree(TestStep model) {
-		return callTreeNodeNamed(model.contents.restoreString)
-	}
-	
-	// ToDo: AssertionTestStep, TestStepWithAssignment, AssignmentThroughPath
-	
-	
-	def dispatch CallTreeNode toCallTree(EObject model) {
-		return callTreeNodeNamed(model.class.simpleName)
+	def dispatch CallTreeNode toCallTree(AbstractTestStep model) {
+		return model.namedCallTreeNode
 	}
 
-	
-	
+	def dispatch CallTreeNode toCallTree(TestStep model) {
+		return model.namedCallTreeNode => [
+			if (model.hasMacroContext) {
+				children += model.findMacro.contexts.map[toCallTree]
+			}
+		]
+	}
+
+	def dispatch CallTreeNode toCallTree(EObject model) {
+		return model.namedCallTreeNode
+	}
+
 	def dispatch CallTreeNode toNamedCallTreeNode(SpecificationStepImplementation model) {
 		return callTreeNodeNamed(model.contents.restoreString)
 	}
-	
+
 	def dispatch CallTreeNode toNamedCallTreeNode(TestSetup model) {
 		return callTreeNodeNamed(testSetupDisplayName)
 	}
-	
+
 	def dispatch CallTreeNode toNamedCallTreeNode(TestCleanup model) {
 		return callTreeNodeNamed(testCleanupDisplayName)
 	}
-	
-	
-	
+
+	def namedCallTreeNode(EObject model) {
+		return callTreeNodeNamed(model.stringify)
+	}
+
 	def callTreeNodeNamed(String name) {
 		return createCallTreeNode => [
 			displayname = name
 		]
 	}
-	
+
 }

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
@@ -66,8 +66,8 @@ import org.testeditor.tcl.TestStepWithAssignment
 import org.testeditor.tcl.VariableReference
 import org.testeditor.tcl.VariableReferencePathAccess
 import org.testeditor.tcl.dsl.jvmmodel.macro.MacroHelper
+import org.testeditor.tcl.dsl.messages.TclElementStringifier
 import org.testeditor.tcl.util.TclModelUtil
-import org.testeditor.tsl.SpecificationStep
 import org.testeditor.tsl.StepContent
 import org.testeditor.tsl.StepContentValue
 
@@ -82,6 +82,7 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 	@Inject extension JvmTypesBuilder
 	@Inject extension ModelUtil
 	@Inject extension TclModelUtil
+	@Inject extension TclElementStringifier
 	@Inject TclAssertCallBuilder assertCallBuilder
 	@Inject IQualifiedNameProvider nameProvider
 	@Inject JvmModelHelper jvmModelHelper
@@ -334,22 +335,8 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 		output.newLine
 	}
 	
-	private def String reportString(SpecificationStep step) {
-		val node = NodeModelUtils.getNode(step)
-		val contentsString = if (node !== null) {
-				val text = NodeModelUtils.getTokenText(node)
-				val relevantText = text.split('\n').map[trim].takeWhile[!startsWith("Component")&&!startsWith("Mask")&&!startsWith("Macro")].join(' ')
-				val contentsText = relevantText.substring(text.indexOf('*') + 1)
-				contentsText
-			} else {
-				// if no node model is present do naiive restoration of model (spacing information is lost)
-				step.contents.restoreString
-			}.trim
-		return contentsString
-	}
-	
 	private def void generate(SpecificationStepImplementation step, ITreeAppendable output) {
-		output.appendReporterEnterCall(SemanticUnit.SPECIFICATION_STEP, step.reportString) 
+		output.appendReporterEnterCall(SemanticUnit.SPECIFICATION_STEP, step.stringify) 
 		step.contexts.forEach[generateContext(output.trace(it))]
 	}
 
@@ -360,7 +347,7 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 	}
 
 	private def dispatch void generateContext(ComponentTestStepContext context, ITreeAppendable output) {
-		output.appendReporterEnterCall(SemanticUnit.COMPONENT, context.component.name)
+		output.appendReporterEnterCall(SemanticUnit.COMPONENT, context.stringify)
 		context.steps.forEach[generate(output.trace(it))]
 	}
 
@@ -433,12 +420,11 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 	}
 	
 	private def void toUnitTestCodeLineOfJsonAssignment(AssignmentThroughPath step, ITreeAppendable output) {
-		val varRef = step.getVariableReference
-
-		val stepLog = '''«varRef?.restoreString» = «assertCallBuilder.assertionText(step.expression)»'''
+		val stepLog = step.stringify
 		logger.debug("generating code line for test step='{}'.", stepLog)
 		output.appendReporterEnterCall(SemanticUnit.STEP, '''«stepLog»''')
 
+		val varRef = step.getVariableReference
 		val expression = step.expression.actualMostSpecific
 		switch expression {
 			JsonValue: {
@@ -645,8 +631,8 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 			output.trace(step, TEST_STEP_WITH_ASSIGNMENT__VARIABLE, 0) => [
 				// TODO should we use output.declareVariable here?
 				// val variableName = output.declareVariable(step.variableName, step.variableName)
-				val partialCodeLine = '''«operation.returnType.identifier» «step.variable.name» = '''
-				output.appendReporterEnterCall(SemanticUnit.STEP, '''«partialCodeLine.trim» «stepLog.trim»''', variables)
+				val partialCodeLine = step.leftHandSideAssignmentCodeLine
+				output.appendReporterEnterCall(SemanticUnit.STEP, '''«step.leftHandSideAssignmentCodeLine.trim» «step.stringifyTestStep»''', variables)
 				output.append(partialCodeLine) // please call with string, since tests checks against expected string which fails for passing ''' directly
 			]
 		} else {

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/jvmmodel/TclJvmModelInferrer.xtend
@@ -631,8 +631,8 @@ class TclJvmModelInferrer extends AbstractModelInferrer {
 			output.trace(step, TEST_STEP_WITH_ASSIGNMENT__VARIABLE, 0) => [
 				// TODO should we use output.declareVariable here?
 				// val variableName = output.declareVariable(step.variableName, step.variableName)
-				val partialCodeLine = step.leftHandSideAssignmentCodeLine
-				output.appendReporterEnterCall(SemanticUnit.STEP, '''«step.leftHandSideAssignmentCodeLine.trim» «step.stringifyTestStep»''', variables)
+				val partialCodeLine = '''«operation.returnType.identifier» «step.variable.name» = '''
+				output.appendReporterEnterCall(SemanticUnit.STEP, step.stringify, variables)
 				output.append(partialCodeLine) // please call with string, since tests checks against expected string which fails for passing ''' directly
 			]
 		} else {

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/messages/TclElementStringifier.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/messages/TclElementStringifier.xtend
@@ -49,7 +49,7 @@ class TclElementStringifier {
 	}
 
 	def dispatch String stringify(TestStepWithAssignment it) {
-		return '''«leftHandSideAssignmentCodeLine.trim» «stringifyTestStep»'''
+		return '''«variable.name» = «stringifyTestStep» «typeInfoSuffix»'''
 	}
 
 	def dispatch String stringify(AssertionTestStep it) {
@@ -72,18 +72,18 @@ class TclElementStringifier {
 		logger.warn('''Don't know how to stringify elements of type «it.class.name»; using simple class name.''')
 		return class.simpleName
 	}
-
-	def String leftHandSideAssignmentCodeLine(TestStepWithAssignment it) {
-		var leftHandSideAssignmentCodeLine = ''
+	
+	def String typeInfoSuffix(TestStepWithAssignment it) {
+		var typeInfoSuffix = ''
 		if (hasComponentContext) {
 			val operation = interaction.defaultMethod?.operation
 			if (operation !== null) {
-				leftHandSideAssignmentCodeLine = '''«operation.returnType.identifier» «variable.name» = '''
+				typeInfoSuffix = '''[«operation.returnType.identifier»]'''
 			} else {
 				logger.warn('''Interaction type '«interaction.name»' does not have a proper method reference.''')
 			}
 		}
-		return leftHandSideAssignmentCodeLine
+		return typeInfoSuffix
 	}
 
 	def stringifyTestStep(TestStep it) {

--- a/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/messages/TclElementStringifier.xtend
+++ b/tcl/org.testeditor.tcl.dsl/src/org/testeditor/tcl/dsl/messages/TclElementStringifier.xtend
@@ -1,0 +1,93 @@
+package org.testeditor.tcl.dsl.messages
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import org.eclipse.emf.ecore.EObject
+import org.slf4j.LoggerFactory
+import org.testeditor.tcl.AssertionTestStep
+import org.testeditor.tcl.AssignmentThroughPath
+import org.testeditor.tcl.ComponentTestStepContext
+import org.testeditor.tcl.MacroTestStepContext
+import org.testeditor.tcl.TestCase
+import org.testeditor.tcl.TestStep
+import org.testeditor.tcl.TestStepWithAssignment
+import org.testeditor.tcl.dsl.jvmmodel.TclAssertCallBuilder
+import org.testeditor.tcl.util.TclModelUtil
+import org.testeditor.tsl.SpecificationStep
+
+import static extension org.eclipse.xtext.nodemodel.util.NodeModelUtils.getNode
+import static extension org.eclipse.xtext.nodemodel.util.NodeModelUtils.getTokenText
+
+@Singleton
+class TclElementStringifier {
+
+	static val logger = LoggerFactory.getLogger(TclElementStringifier)
+
+	@Inject extension TclModelUtil
+	@Inject extension TclAssertCallBuilder
+
+	def dispatch String stringify(TestCase it) {
+		return name
+	}
+
+	// SpecificationStep and TestStep each define 'contents' as a field of type EList<StepContent>
+	// but its  not in a common super-type, because of different semantics
+	def dispatch String stringify(SpecificationStep it) {
+		val node = getNode
+		return if (node !== null) {
+			val text = node.tokenText
+			val relevantText = text.split('\n').map[trim].takeWhile[!startsWith("Component") && !startsWith("Mask") && !startsWith("Macro")].join(' ')
+			relevantText.substring(text.indexOf('*') + 1)
+		} else
+			{
+				contents.restoreString
+			}.trim
+	}
+
+	def dispatch String stringify(TestStep it) {
+		return stringifyTestStep
+	}
+
+	def dispatch String stringify(TestStepWithAssignment it) {
+		return '''«leftHandSideAssignmentCodeLine.trim» «stringifyTestStep»'''
+	}
+
+	def dispatch String stringify(AssertionTestStep it) {
+		return '''assert «assertExpression.assertionText»'''
+	}
+
+	def dispatch String stringify(AssignmentThroughPath it) {
+		return '''«variableReference?.restoreString» = «expression.assertionText»'''
+	}
+
+	def dispatch String stringify(ComponentTestStepContext it) {
+		return component.name
+	}
+
+	def dispatch String stringify(MacroTestStepContext it) {
+		return macroCollection.name
+	}
+
+	def dispatch String stringify(EObject it) {
+		logger.warn('''Don't know how to stringify elements of type «it.class.name»; using simple class name.''')
+		return class.simpleName
+	}
+
+	def String leftHandSideAssignmentCodeLine(TestStepWithAssignment it) {
+		var leftHandSideAssignmentCodeLine = ''
+		if (hasComponentContext) {
+			val operation = interaction.defaultMethod?.operation
+			if (operation !== null) {
+				leftHandSideAssignmentCodeLine = '''«operation.returnType.identifier» «variable.name» = '''
+			} else {
+				logger.warn('''Interaction type '«interaction.name»' does not have a proper method reference.''')
+			}
+		}
+		return leftHandSideAssignmentCodeLine
+	}
+
+	def stringifyTestStep(TestStep it) {
+		return contents.restoreString.trim
+	}
+
+}


### PR DESCRIPTION
* extracted some code from `TclJvmModelInferrer` for building log entry strings from test steps and other TCL model elements, and put it into the utility class, `TclElementStringifier`, along with other methods for "stringification"
* `CallTreeBuilder` should now handle test steps in both component and macro context, and resolve macro and fixture calls.

Left to do:
* handling configs
* complex test with non-trivial setup, cleanup, and test steps
* test nested macro calls (e.g. macro calls macro calls fixture method)