### PR TITLE
put target platform compile in a separate stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,11 @@ before_install:
   - export MAVEN_OPTS="-Xms256m -Xmx512m"
 stages:
   - name: compileFeature
-    if: (NOT (branch IN (master, develop))) AND (NOT(tag =~ ^v.*$))
+    # just the language is built (te-web needs no more)
+    if: (NOT (branch IN (master, develop) OR tag =~ ^v.*$ OR type IN (pull_request)))
   - name: compileRcp
-    if: branch IN (master, develop) OR tag =~ ^v.*$
+    # complete build (including eclipse plugins, rcp and product)
+    if: branch IN (master, develop) OR tag =~ ^v.*$ OR type IN (pull_request)
 jobs:
   include:
     - stage: compileFeature
@@ -32,4 +34,4 @@ jobs:
       - mvn clean install -Dmaven.test.failure.ignore -Dsurefire.useFile=false -Dtycho.localArtifacts=ignore -Prcp,product
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-  - ./.travis-publishOnRelease.sh
+  - ./.travis-publishOnRelease.sh # publishes only if tagged with v.*


### PR DESCRIPTION
publishing after tagging does not work for plugins, since it is executed after compileFeature (which should not run when publishing).